### PR TITLE
Improve defaults & config handling

### DIFF
--- a/docs.txt
+++ b/docs.txt
@@ -1,0 +1,5 @@
+Request
+  @link: https://developer.mozilla.org/en-US/docs/Web/API/Request/Request
+
+Request.mode
+  @link: https://developer.mozilla.org/en-US/docs/Web/API/Request/mode

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,42 @@
+const merge = require('./utils').merge;
+
+const DEFAULT_HEADERS = {
+  'Accept': 'application/json, text/plain, */*', // eslint-disable-line quote-props
+  'Content-Type': 'application/json'
+};
+
+const DEFAULT_CONFIG = {
+  xsrfCookieName: 'XSRF-TOKEN',
+  xsrfHeaderName: 'X-XSRF-TOKEN'
+};
+
+class Config {
+  constructor(config = {}) {
+    this._defaults = merge(DEFAULT_CONFIG, { headers: DEFAULT_HEADERS });
+    this._config   = {};
+
+    this.set(config);
+  }
+
+  mergeWithDefaults(...configParams) {
+    const config = merge(this._defaults, this._config, ...configParams);
+    if (
+      typeof config.body === 'object' &&
+      config.headers &&
+      config.headers['Content-Type'] === 'application/json'
+    ) {
+      config.body = JSON.stringify(config.body);
+    }
+    return config;
+  }
+
+  set(config) {
+    this._config = merge(this._config, config);
+  }
+
+  get() {
+    return merge(this._defaults, this._config);
+  }
+}
+
+module.exports = Config;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,12 +1,15 @@
 require('whatwg-fetch');
 const buildQuery = require('trae-query').buildQuery;
+
 const Middleware = require('./middleware');
+const Config = require('./config');
 
 class Trae {
   constructor(config = {}) {
-    this._baseUrl    = config.baseUrl || '';
     this._middleware = new Middleware();
+    this._config     = new Config(config);
 
+    this.baseUrl(config.baseUrl || '');
     this._initMethodsWithBody();
     this._initMethodsWithNoBody();
   }
@@ -24,6 +27,22 @@ class Trae {
     }
   }
 
+  defaults(config) {
+    if (typeof config === 'undefined') {
+      return this._config.get();
+    }
+    this._config.set(config);
+    return this._config.get();
+  }
+
+  baseUrl(baseUrl) {
+    if (typeof baseUrl === 'undefined') {
+      return this._baseUrl;
+    }
+    this._baseUrl = baseUrl;
+    return this._baseUrl;
+  }
+
   _fetch(url, config) {
     return this._middleware.resolveRequests(config)
     .then(config => fetch(url, config))
@@ -34,10 +53,10 @@ class Trae {
   _initMethodsWithNoBody() {
     ['get', 'delete', 'head'].forEach((method) => {
       this[method] = (path, config = {}) => {
-        const url         = buildQuery(`${this._baseUrl}${path}`, config.params);
-        const defaultConf = this.constructor._defaultConfig({ method });
+        const mergedConfig = this._config.mergeWithDefaults(config, { method });
+        const url          = buildQuery(`${this._baseUrl}${path}`, config.params);
 
-        return this._fetch(url, Object.assign({}, defaultConf, config));
+        return this._fetch(url, mergedConfig);
       };
     });
   }
@@ -45,23 +64,12 @@ class Trae {
   _initMethodsWithBody() {
     ['post', 'put', 'patch'].forEach((method) => {
       this[method] = (path, body, config) => {
-        const url         = `${this._baseUrl}${path}`;
-        const defaultConf = this.constructor._defaultConfig({ body, method });
+        const mergedConfig = this._config.mergeWithDefaults(config, { body, method });
+        const url          = `${this._baseUrl}${path}`;
 
-        return this._fetch(url, Object.assign({}, defaultConf, config));
+        return this._fetch(url, mergedConfig);
       };
     });
-  }
-
-  static _defaultConfig(opts = {}) {
-    const config = {
-      method : opts.method,
-      headers: { 'Content-Type': 'application/json' }
-    };
-    if (opts.body) {
-      config.body = JSON.stringify(opts.body);
-    }
-    return config;
   }
 
   static _responseHandler(response) {
@@ -75,6 +83,7 @@ class Trae {
     }
     return response.text();
   }
+
 }
 
 module.exports = new Trae();

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,12 +3,16 @@ const buildQuery = require('trae-query').buildQuery;
 const Middleware = require('./middleware');
 
 class Trae {
-  constructor(baseUrl = '' ) {
-    this._baseUrl    = baseUrl;
+  constructor(config = {}) {
+    this._baseUrl    = config.baseUrl || '';
     this._middleware = new Middleware();
 
     this._initMethodsWithBody();
     this._initMethodsWithNoBody();
+  }
+
+  create(config) {
+    return new this.constructor(config);
   }
 
   use(middlewares = {}) {
@@ -73,5 +77,4 @@ class Trae {
   }
 }
 
-exports = module.exports = new Trae();
-exports.Trae = Trae;
+module.exports = new Trae();

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,20 +2,13 @@ require('whatwg-fetch');
 const buildQuery = require('trae-query').buildQuery;
 const Middleware = require('./middleware');
 
-
 class Trae {
-  constructor() {
-    this._baseUrl    = '';
+  constructor(baseUrl = '' ) {
+    this._baseUrl    = baseUrl;
     this._middleware = new Middleware();
 
     this._initMethodsWithBody();
     this._initMethodsWithNoBody();
-  }
-
-  init(opts = {}) {
-    if (opts.baseUrl) {
-      this._baseUrl = opts.baseUrl;
-    }
   }
 
   use(middlewares = {}) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,9 @@
+const mergeRecursive = require('merge').recursive;
+
+function merge(...params)  {
+  return mergeRecursive(true, ...params);
+}
+
+module.exports = {
+  merge
+};

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     ]
   },
   "dependencies": {
+    "merge": "^1.2.0",
     "trae-query": "^0.1.0",
     "whatwg-fetch": "^1.0.0"
   }

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -1,0 +1,195 @@
+/* global describe it expect */
+const merge = require('../lib/utils').merge;
+
+const Config = require('../lib/config');
+
+const DEFAULT_HEADERS = {
+  Accept: 'application/json, text/plain, */*',
+  'Content-Type': 'application/json'
+};
+
+const DEFAULT_CONFIG = {
+  xsrfCookieName: 'XSRF-TOKEN',
+  xsrfHeaderName: 'X-XSRF-TOKEN'
+};
+
+const defaults = merge(DEFAULT_CONFIG, { headers: DEFAULT_HEADERS });
+
+const configParams = {
+  mode: 'no-cors',
+  credentials: 'same-origin'
+};
+
+function getConfigWithParams() {
+  return new Config(configParams);
+}
+
+describe('Config -> config', () => {
+  it('initializes with the default fetch config', () => {
+    const config = new Config();
+
+    expect(config._config).toEqual({});
+    expect(config._defaults).toEqual(defaults);
+    expect(config.get()).toEqual(defaults);
+  });
+
+  it('initializes with the defaults merged with the provided config', () => {
+    const config = getConfigWithParams();
+
+    expect(config._config).toEqual(configParams);
+    expect(config._defaults).toEqual(defaults);
+    expect(config.get()).toEqual(merge(defaults, configParams));
+  });
+
+  describe('set', () => {
+
+    it('merges the provided config with this._config', () => {
+      const config = getConfigWithParams();
+      config.set({
+        mode: 'cors',
+        headers: {
+          'X-ACCESS-TOKE': 'aasdljhf2kjrasdf2l3jrhn2'
+        }
+      });
+
+      expect(config._config).toEqual({
+        mode: 'cors',
+        credentials: 'same-origin',
+        headers: {
+          'X-ACCESS-TOKE': 'aasdljhf2kjrasdf2l3jrhn2'
+        }
+      });
+    });
+
+  });
+
+  describe('get', () => {
+
+    it('returns the merged _defaults and _config', () => {
+      const config = getConfigWithParams();
+      config.set({
+        mode: 'cors',
+        headers: {
+          'X-ACCESS-TOKE': 'aasdljhf2kjrasdf2l3jrhn2'
+        }
+      });
+
+      expect(config.get()).toEqual({
+        mode: 'cors',
+        credentials: 'same-origin',
+        xsrfCookieName: 'XSRF-TOKEN',
+        xsrfHeaderName: 'X-XSRF-TOKEN',
+        headers: {
+          'X-ACCESS-TOKE': 'aasdljhf2kjrasdf2l3jrhn2',
+          Accept: 'application/json, text/plain, */*',
+          'Content-Type': 'application/json'
+        }
+      });
+    });
+
+  });
+
+  describe('mergeWithDefaults', () => {
+
+    it('returns body stringified according to Content-Type', () => {
+      const config = new Config();
+
+      const actual = config.mergeWithDefaults({ body: { foo: 'bar' } });
+      expect(actual).toEqual({
+        xsrfCookieName: 'XSRF-TOKEN',
+        xsrfHeaderName: 'X-XSRF-TOKEN',
+        headers: {
+          Accept: 'application/json, text/plain, */*',
+          'Content-Type': 'application/json'
+        },
+        body: '{"foo":"bar"}'
+      });
+    });
+
+    it('returns the config merged with the params', () => {
+      const config = new Config({ mode: 'no-cors' });
+
+      const actual = config.mergeWithDefaults({ credentials: 'same-origin' });
+      expect(actual).toEqual({
+        xsrfCookieName: 'XSRF-TOKEN',
+        xsrfHeaderName: 'X-XSRF-TOKEN',
+        headers: {
+          Accept: 'application/json, text/plain, */*',
+          'Content-Type': 'application/json'
+        },
+        mode: 'no-cors',
+        credentials: 'same-origin'
+      });
+    });
+
+    it('returns the config merged with the params', () => {
+      const config = new Config({ mode: 'no-cors' });
+
+      const actual = config.mergeWithDefaults({ credentials: 'same-origin' });
+      expect(actual).toEqual({
+        xsrfCookieName: 'XSRF-TOKEN',
+        xsrfHeaderName: 'X-XSRF-TOKEN',
+        headers: {
+          Accept: 'application/json, text/plain, */*',
+          'Content-Type': 'application/json'
+        },
+        mode: 'no-cors',
+        credentials: 'same-origin'
+      });
+    });
+
+    it('merges all the params passed', () => {
+      const config = new Config({ mode: 'no-cors' });
+
+      const actual = config.mergeWithDefaults(
+        { credentials: 'same-origin' },
+        { headers: { 'Content-Type': 'text/plain' } }
+      );
+      expect(actual).toEqual({
+        xsrfCookieName: 'XSRF-TOKEN',
+        xsrfHeaderName: 'X-XSRF-TOKEN',
+        headers: {
+          Accept: 'application/json, text/plain, */*',
+          'Content-Type': 'text/plain'
+        },
+        mode: 'no-cors',
+        credentials: 'same-origin'
+      });
+    });
+
+    it('does not mutate _config or _defaults', () => {
+      const config = new Config({ mode: 'no-cors' });
+
+      const defaults = {
+        headers: {
+          Accept: 'application/json, text/plain, */*',
+          'Content-Type': 'application/json'
+        },
+        xsrfCookieName: 'XSRF-TOKEN',
+        xsrfHeaderName: 'X-XSRF-TOKEN'
+      };
+
+      expect(config._config).toEqual({ mode: 'no-cors' });
+      expect(config._defaults).toEqual(defaults);
+
+      const actual = config.mergeWithDefaults(
+        { headers: { 'Content-Type': 'text/plain' } },
+        { mode: 'cors' }
+      );
+      expect(actual).toEqual({
+        xsrfCookieName: 'XSRF-TOKEN',
+        xsrfHeaderName: 'X-XSRF-TOKEN',
+        headers: {
+          Accept: 'application/json, text/plain, */*',
+          'Content-Type': 'text/plain'
+        },
+        mode: 'cors'
+      });
+
+      expect(config._config).toEqual({ mode: 'no-cors' });
+      expect(config._defaults).toEqual(defaults);
+    });
+
+  });
+
+});

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -23,6 +23,15 @@ describe('trae', () => {
     });
   });
 
+  describe('baseUrl', () => {
+    it('sets the baseUrl or returns if no params are passed', () => {
+      const apiFoo = trae.create();
+      apiFoo.baseUrl('/api/foo');
+      expect(apiFoo._baseUrl).toEqual('/api/foo');
+      expect(apiFoo.baseUrl()).toEqual('/api/foo');
+    });
+  });
+
 });
 
 describe('HTTP -> http', () => {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -10,21 +10,11 @@ afterEach(() => {
 const TEST_URL = 'http://localhost:8080/foo';
 
 describe('HTTP -> http', () => {
-  it('Initilize default attributes', () => {
-    const trae = new Trae();
+  it('Initilize default attributes on the constructor', () => {
+    const trae = new Trae('/api');
 
-    expect(trae._baseUrl).toEqual('');
+    expect(trae._baseUrl).toEqual('/api');
     expect(trae._middleware).toBeDefined();
-  });
-
-  describe('init', () => {
-    it('overwrite default attributes', () => {
-      const trae    = new Trae();
-      const baseUrl = 'http://localhost:8080';
-
-      trae.init({ baseUrl });
-      expect(trae._baseUrl).toBe(baseUrl);
-    });
   });
 
   describe('get', () => {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,25 +1,34 @@
 /* global describe it expect afterEach */
 
 const fetchMock = require('fetch-mock');
-const Trae      = require('../lib').Trae;
+const trae      = require('../lib');
 
 afterEach(() => {
   fetchMock.restore();
 });
 
-const TEST_URL = 'http://localhost:8080/foo';
+const TEST_URL = 'http://localhost:8080/api';
 
-describe('HTTP -> http', () => {
-  it('Initilize default attributes on the constructor', () => {
-    const trae = new Trae('/api');
-
-    expect(trae._baseUrl).toEqual('/api');
+describe('trae', () => {
+  it('exposed as a singleton instance of Trae class with the default config', () => {
+    expect(trae._baseUrl).toEqual('');
     expect(trae._middleware).toBeDefined();
   });
 
+  describe('create', () => {
+    it('returns a new instance of Trae with the provided config as defaults', () => {
+      const apiFoo = trae.create({ baseUrl: '/api/foo' });
+      expect(apiFoo._baseUrl).toEqual('/api/foo');
+      expect(apiFoo._middleware).toBeDefined();
+    });
+  });
+
+});
+
+describe('HTTP -> http', () => {
+
   describe('get', () => {
     it('makes a GET request to baseURL + path', () => {
-      const trae = new Trae();
       const url  = `${TEST_URL}/foo`;
 
       fetchMock.mock(url, {
@@ -44,7 +53,6 @@ describe('HTTP -> http', () => {
 
   describe('del', () => {
     it('makes a DELETE request to baseURL + path', () => {
-      const trae = new Trae();
       const url  = `${TEST_URL}/foo`;
 
       fetchMock.mock(url, {
@@ -69,7 +77,6 @@ describe('HTTP -> http', () => {
 
   describe('head', () => {
     it('makes a HEAD request to baseURL + path', () => {
-      const trae = new Trae();
       const url  = `${TEST_URL}/foo`;
 
       fetchMock.mock(url, {
@@ -90,7 +97,6 @@ describe('HTTP -> http', () => {
 
   describe('post', () => {
     it('makes a POST request to baseURL + path', () => {
-      const trae = new Trae();
       const url  = `${TEST_URL}/foo`;
 
       fetchMock.mock(url, {
@@ -115,7 +121,6 @@ describe('HTTP -> http', () => {
 
   describe('put', () => {
     it('makes a PUT request to baseURL + path', () => {
-      const trae = new Trae();
       const url  = `${TEST_URL}/foo`;
 
       fetchMock.mock(url, {
@@ -140,7 +145,6 @@ describe('HTTP -> http', () => {
 
   describe('patch', () => {
     it('makes a PATCH request to baseURL + path', () => {
-      const trae = new Trae();
       const url  = `${TEST_URL}/foo`;
 
       fetchMock.mock(url, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -299,6 +299,12 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+bl@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-1.1.2.tgz#fdca871a99713aa00d19e3bbba41c44787a65398"
+  dependencies:
+    readable-stream "~2.0.5"
+
 boom@2.x.x:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
@@ -494,6 +500,16 @@ core-js@^2.4.0:
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+
+coveralls@^2.11.14:
+  version "2.11.14"
+  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-2.11.14.tgz#645a05ac72aa4f2ee811c667390d4ad36f0c2e26"
+  dependencies:
+    js-yaml "3.6.1"
+    lcov-parse "0.0.10"
+    log-driver "1.2.5"
+    minimist "1.2.0"
+    request "2.75.0"
 
 cross-spawn-async@^2.0.0:
   version "2.2.5"
@@ -949,6 +965,14 @@ for-own@^0.1.4:
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
+
+form-data@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.0.0.tgz#6f0aebadcc5da16c13e1ecc11137d85f9b883b25"
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.5"
+    mime-types "^2.1.11"
 
 form-data@~2.1.1:
   version "2.1.1"
@@ -1595,7 +1619,7 @@ js-tokens@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-2.0.0.tgz#79903f5563ee778cc1162e6dcf1a0027c97f9cb5"
 
-js-yaml@^3.5.1, js-yaml@3.x:
+js-yaml@^3.5.1, js-yaml@3.6.1, js-yaml@3.x:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.6.1.tgz#6e5fe67d8b205ce4d22fad05b7781e8dadcc4b30"
   dependencies:
@@ -1691,6 +1715,10 @@ lcid@^1.0.0:
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
   dependencies:
     invert-kv "^1.0.0"
+
+lcov-parse@0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-0.0.10.tgz#1b0b8ff9ac9c7889250582b70b71315d9da6d9a3"
 
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
@@ -1798,6 +1826,10 @@ lodash@^4.0.0, lodash@^4.2.0, lodash@^4.3.0:
   version "4.16.6"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.16.6.tgz#d22c9ac660288f3843e16ba7d2b5d06cca27d777"
 
+log-driver@1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.5.tgz#7ae4ec257302fd790d557cb10c97100d857b0056"
+
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
@@ -1835,7 +1867,7 @@ marked@^0.3.6:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.6.tgz#b2c6c618fccece4ef86c4fc6cb8a7cbf5aeda8d7"
 
-merge@^1.1.3:
+merge, merge@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
 
@@ -1861,7 +1893,7 @@ mime-db@~1.24.0:
   version "1.24.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.24.0.tgz#e2d13f939f0016c6e4e9ad25a8652f126c467f0c"
 
-mime-types@^2.1.12, mime-types@~2.1.7:
+mime-types@^2.1.11, mime-types@^2.1.12, mime-types@~2.1.7:
   version "2.1.12"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.12.tgz#152ba256777020dd4663f54c2e7bc26381e71729"
   dependencies:
@@ -1879,7 +1911,7 @@ minimatch@2.x:
   dependencies:
     brace-expansion "^1.0.0"
 
-minimist@^1.1.1:
+minimist@^1.1.1, minimist@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -2157,6 +2189,10 @@ punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
+qs@~6.2.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.2.1.tgz#ce03c5ff0935bc1d9d69a9f14cbd18e568d67625"
+
 qs@~6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.0.tgz#f403b264f23bc01228c74131b407f18d5ea5d442"
@@ -2183,7 +2219,7 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-readable-stream@~2.0.0:
+readable-stream@~2.0.0, readable-stream@~2.0.5:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.0.6.tgz#8f90341e68a53ccc928788dacfcd11b36eb9b78e"
   dependencies:
@@ -2260,6 +2296,32 @@ request@^2.55.0:
     node-uuid "~1.4.7"
     oauth-sign "~0.8.1"
     qs "~6.3.0"
+    stringstream "~0.0.4"
+    tough-cookie "~2.3.0"
+    tunnel-agent "~0.4.1"
+
+request@2.75.0:
+  version "2.75.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.75.0.tgz#d2b8268a286da13eaa5d01adf5d18cc90f657d93"
+  dependencies:
+    aws-sign2 "~0.6.0"
+    aws4 "^1.2.1"
+    bl "~1.1.2"
+    caseless "~0.11.0"
+    combined-stream "~1.0.5"
+    extend "~3.0.0"
+    forever-agent "~0.6.1"
+    form-data "~2.0.0"
+    har-validator "~2.0.6"
+    hawk "~3.1.3"
+    http-signature "~1.1.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.7"
+    node-uuid "~1.4.7"
+    oauth-sign "~0.8.1"
+    qs "~6.2.0"
     stringstream "~0.0.4"
     tough-cookie "~2.3.0"
     tunnel-agent "~0.4.1"


### PR DESCRIPTION
This PR adds the `Config` class to handle default & configurable configuration for requests.

`trae` API changes:

```js
// Create a tea instance with default config
const auth = trae.create({
  headers: {
    'X-CSRF-Token': getToken()
  }
});

// Set default config after creating
auth.defaults({ credentials: 'same-origin' });

// Set base url
auth.baseUrl('/api/auth');
```

Both `trae.defaults` & `trae.baseUrl` act as a getter when no params are passed.

Default config will get merged with the config passed on a request method. The former will take priority.

Also:

- adds `trae.create` method to create `trae` instances, this allows to have different defaults.
- removes `trae.init` method.
- `trae` is only exposed as a singleton, the instantiation is done with the `trae.create` method.