### PR TITLE
Add skip util & skip baseUrl when passing params to Config.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,12 +2,13 @@ require('whatwg-fetch');
 const buildQuery = require('trae-query').buildQuery;
 
 const Middleware = require('./middleware');
-const Config = require('./config');
+const Config     = require('./config');
+const skip       = require('./utils').skip;
 
 class Trae {
   constructor(config = {}) {
     this._middleware = new Middleware();
-    this._config     = new Config(config);
+    this._config     = new Config(skip(config, ['baseUrl']));
 
     this.baseUrl(config.baseUrl || '');
     this._initMethodsWithBody();
@@ -31,7 +32,8 @@ class Trae {
     if (typeof config === 'undefined') {
       return this._config.get();
     }
-    this._config.set(config);
+    this._config.set(skip(config, ['baseUrl']));
+    config.baseUrl && this.baseUrl(config.baseUrl);
     return this._config.get();
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,9 +1,33 @@
 const mergeRecursive = require('merge').recursive;
 
+/**
+ * Recursively merge objects
+ *
+ * @param {Object} objects to merge
+ * @return {Object} the merged objects
+ */
 function merge(...params)  {
   return mergeRecursive(true, ...params);
 }
 
+/**
+ * Returns an object with the skipped properties
+ *
+ * @param {Object} obj the object to skip properties from
+ * @param {[String]} keys keys of the properties to skip
+ * @return {Object} the object with the properties skipped
+ */
+function skip(obj, keys) {
+  const skipped = {};
+  Object.keys(obj).forEach((objKey) => {
+    if (keys.indexOf(objKey) === -1) {
+      skipped[objKey] = obj[objKey];
+    }
+  });
+  return skipped;
+}
+
 module.exports = {
-  merge
+  merge,
+  skip
 };

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -1,0 +1,33 @@
+/* globals describe it expect */
+const utils = require('../lib/utils');
+
+describe('utils', () => {
+  describe('skip', () => {
+    it('returns an object without the properties to skip', () => {
+      const obj = {
+        foo: 'bar',
+        baz: [1, 2, 3],
+        nested: {
+          foo: 'bar'
+        }
+      };
+      const expected = {
+        baz: [1, 2, 3],
+        nested: {
+          foo: 'bar'
+        }
+      };
+      const actual = utils.skip(obj, ['foo']);
+      expect(actual).toEqual(expected);
+    });
+
+    it('returns the same object if the keys are not on the object', () => {
+      const obj = {
+        foo: 'bar'
+      };
+
+      const actual = utils.skip(obj, ['baz']);
+      expect(actual).toEqual(obj);
+    });
+  });
+});


### PR DESCRIPTION
When creating an instance or setting the defaults, if the config object has a `baseUrl` property it will set the `baseUrl` but will be skipping when passing the arguments to `Config`.