### PR TITLE
Add tests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,10 +21,10 @@ class Trae {
 
   use(middlewares = {}) {
     if (middlewares.config) {
-      this.middleware.request(middlewares.config);
+      this._middleware.request(middlewares.config);
     }
     if (middlewares.fulfill || middlewares.reject) {
-      this.middleware.response(middlewares.fulfill, middlewares.reject);
+      this._middleware.response(middlewares.fulfill, middlewares.reject);
     }
   }
 

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -1,3 +1,5 @@
+const res = response => Promise.resolve(response);
+const rej = err => Promise.reject(err);
 
 class Middleware {
   constructor() {
@@ -10,10 +12,7 @@ class Middleware {
     return this._req.length - 1;
   }
 
-  response(fulfill, reject) {
-    fulfill || (fulfill = res => Promise.resolve(res));
-    reject  || (reject  = err => Promise.reject(err));
-
+  response(fulfill = res, reject = rej) {
     this._res.push({ fulfill, reject });
     return this._res.length - 1;
   }

--- a/test/__snapshots__/config.spec.js.snap
+++ b/test/__snapshots__/config.spec.js.snap
@@ -1,0 +1,86 @@
+exports[`Config -> config get returns the merged _defaults and _config 1`] = `
+Object {
+  "credentials": "same-origin",
+  "headers": Object {
+    "Accept": "application/json, text/plain, */*",
+    "Content-Type": "application/json",
+    "X-ACCESS-TOKE": "aasdljhf2kjrasdf2l3jrhn2",
+  },
+  "mode": "cors",
+  "xsrfCookieName": "XSRF-TOKEN",
+  "xsrfHeaderName": "X-XSRF-TOKEN",
+}
+`;
+
+exports[`Config -> config mergeWithDefaults does not mutate _config or _defaults 1`] = `
+Object {
+  "headers": Object {
+    "Accept": "application/json, text/plain, */*",
+    "Content-Type": "text/plain",
+  },
+  "mode": "cors",
+  "xsrfCookieName": "XSRF-TOKEN",
+  "xsrfHeaderName": "X-XSRF-TOKEN",
+}
+`;
+
+exports[`Config -> config mergeWithDefaults merges all the params passed 1`] = `
+Object {
+  "credentials": "same-origin",
+  "headers": Object {
+    "Accept": "application/json, text/plain, */*",
+    "Content-Type": "text/plain",
+  },
+  "mode": "no-cors",
+  "xsrfCookieName": "XSRF-TOKEN",
+  "xsrfHeaderName": "X-XSRF-TOKEN",
+}
+`;
+
+exports[`Config -> config mergeWithDefaults returns body stringified according to Content-Type 1`] = `
+Object {
+  "body": "{\"foo\":\"bar\"}",
+  "headers": Object {
+    "Accept": "application/json, text/plain, */*",
+    "Content-Type": "application/json",
+  },
+  "xsrfCookieName": "XSRF-TOKEN",
+  "xsrfHeaderName": "X-XSRF-TOKEN",
+}
+`;
+
+exports[`Config -> config mergeWithDefaults returns the config merged with the params 1`] = `
+Object {
+  "credentials": "same-origin",
+  "headers": Object {
+    "Accept": "application/json, text/plain, */*",
+    "Content-Type": "application/json",
+  },
+  "mode": "no-cors",
+  "xsrfCookieName": "XSRF-TOKEN",
+  "xsrfHeaderName": "X-XSRF-TOKEN",
+}
+`;
+
+exports[`Config -> config mergeWithDefaults returns the config merged with the params 2`] = `
+Object {
+  "credentials": "same-origin",
+  "headers": Object {
+    "Accept": "application/json, text/plain, */*",
+    "Content-Type": "application/json",
+  },
+  "mode": "no-cors",
+  "xsrfCookieName": "XSRF-TOKEN",
+  "xsrfHeaderName": "X-XSRF-TOKEN",
+}
+`;
+
+exports[`Config -> config set merges the provided config with this._config 1`] = `
+Object {
+  "credentials": "same-origin",
+  "headers": Object {
+    "X-ACCESS-TOKE": "aasdljhf2kjrasdf2l3jrhn2",
+  },
+  "mode": "cors",
+}
+`;

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -1,0 +1,25 @@
+exports[`HTTP -> http response not ok gets rejected 1`] = `[Error: Not Found]`;
+
+exports[`trae defaults returns the current default config when no params are passed 1`] = `
+Object {
+  "headers": Object {
+    "Accept": "application/json, text/plain, */*",
+    "Content-Type": "application/json",
+  },
+  "xsrfCookieName": "XSRF-TOKEN",
+  "xsrfHeaderName": "X-XSRF-TOKEN",
+}
+`;
+
+exports[`trae defaults sets the default config to be used on all requests for the instance 1`] = `
+Object {
+  "credentials": "same-origin",
+  "headers": Object {
+    "Accept": "application/json, text/plain, */*",
+    "Content-Type": "application/json",
+  },
+  "mode": "no-cors",
+  "xsrfCookieName": "XSRF-TOKEN",
+  "xsrfHeaderName": "X-XSRF-TOKEN",
+}
+`;

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -52,13 +52,7 @@ describe('Config -> config', () => {
         }
       });
 
-      expect(config._config).toEqual({
-        mode: 'cors',
-        credentials: 'same-origin',
-        headers: {
-          'X-ACCESS-TOKE': 'aasdljhf2kjrasdf2l3jrhn2'
-        }
-      });
+      expect(config._config).toMatchSnapshot();
     });
 
   });
@@ -74,17 +68,7 @@ describe('Config -> config', () => {
         }
       });
 
-      expect(config.get()).toEqual({
-        mode: 'cors',
-        credentials: 'same-origin',
-        xsrfCookieName: 'XSRF-TOKEN',
-        xsrfHeaderName: 'X-XSRF-TOKEN',
-        headers: {
-          'X-ACCESS-TOKE': 'aasdljhf2kjrasdf2l3jrhn2',
-          Accept: 'application/json, text/plain, */*',
-          'Content-Type': 'application/json'
-        }
-      });
+      expect(config.get()).toMatchSnapshot();
     });
 
   });
@@ -95,47 +79,21 @@ describe('Config -> config', () => {
       const config = new Config();
 
       const actual = config.mergeWithDefaults({ body: { foo: 'bar' } });
-      expect(actual).toEqual({
-        xsrfCookieName: 'XSRF-TOKEN',
-        xsrfHeaderName: 'X-XSRF-TOKEN',
-        headers: {
-          Accept: 'application/json, text/plain, */*',
-          'Content-Type': 'application/json'
-        },
-        body: '{"foo":"bar"}'
-      });
+      expect(actual).toMatchSnapshot();
     });
 
     it('returns the config merged with the params', () => {
       const config = new Config({ mode: 'no-cors' });
 
       const actual = config.mergeWithDefaults({ credentials: 'same-origin' });
-      expect(actual).toEqual({
-        xsrfCookieName: 'XSRF-TOKEN',
-        xsrfHeaderName: 'X-XSRF-TOKEN',
-        headers: {
-          Accept: 'application/json, text/plain, */*',
-          'Content-Type': 'application/json'
-        },
-        mode: 'no-cors',
-        credentials: 'same-origin'
-      });
+      expect(actual).toMatchSnapshot();
     });
 
     it('returns the config merged with the params', () => {
       const config = new Config({ mode: 'no-cors' });
 
       const actual = config.mergeWithDefaults({ credentials: 'same-origin' });
-      expect(actual).toEqual({
-        xsrfCookieName: 'XSRF-TOKEN',
-        xsrfHeaderName: 'X-XSRF-TOKEN',
-        headers: {
-          Accept: 'application/json, text/plain, */*',
-          'Content-Type': 'application/json'
-        },
-        mode: 'no-cors',
-        credentials: 'same-origin'
-      });
+      expect(actual).toMatchSnapshot();
     });
 
     it('merges all the params passed', () => {
@@ -145,16 +103,7 @@ describe('Config -> config', () => {
         { credentials: 'same-origin' },
         { headers: { 'Content-Type': 'text/plain' } }
       );
-      expect(actual).toEqual({
-        xsrfCookieName: 'XSRF-TOKEN',
-        xsrfHeaderName: 'X-XSRF-TOKEN',
-        headers: {
-          Accept: 'application/json, text/plain, */*',
-          'Content-Type': 'text/plain'
-        },
-        mode: 'no-cors',
-        credentials: 'same-origin'
-      });
+      expect(actual).toMatchSnapshot();
     });
 
     it('does not mutate _config or _defaults', () => {
@@ -176,15 +125,7 @@ describe('Config -> config', () => {
         { headers: { 'Content-Type': 'text/plain' } },
         { mode: 'cors' }
       );
-      expect(actual).toEqual({
-        xsrfCookieName: 'XSRF-TOKEN',
-        xsrfHeaderName: 'X-XSRF-TOKEN',
-        headers: {
-          Accept: 'application/json, text/plain, */*',
-          'Content-Type': 'text/plain'
-        },
-        mode: 'cors'
-      });
+      expect(actual).toMatchSnapshot();
 
       expect(config._config).toEqual({ mode: 'no-cors' });
       expect(config._defaults).toEqual(defaults);


### PR DESCRIPTION
This PR

- adds tests for `trae.default`, `trae.use` & `trae` requests rejection.
- update tests that were matching an object with many properties to use `expect(...).toMatchSnapshot()`.
