### PR TITLE
Create request method

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1,7 +1,7 @@
 const merge = require('./utils').merge;
 
 const DEFAULT_HEADERS = {
-  'Accept': 'application/json, text/plain, */*', // eslint-disable-line quote-props
+  'Accept'      : 'application/json, text/plain, */*', // eslint-disable-line quote-props
   'Content-Type': 'application/json'
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -47,8 +47,11 @@ class Trae {
   }
 
   request(config = {}) {
-    const method = config.method ? config.method.toLowerCase() : 'get';
-    return this[method](config.url, config);
+    config.method || (config.method = 'get');
+    const mergedConfig = this._config.mergeWithDefaults(config);
+    const url          = buildQuery(`${this._baseUrl}${config.url}`, config.params);
+
+    return this._fetch(url, mergedConfig);
   }
 
   _fetch(url, config) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -46,6 +46,11 @@ class Trae {
     return this._baseUrl;
   }
 
+  request(config = {}) {
+    const method = config.method ? config.method.toLowerCase() : 'get';
+    return this[method](config.url, config);
+  }
+
   _fetch(url, config) {
     return this._middleware.resolveRequests(config)
     .then(config => fetch(url, config))

--- a/test/__snapshots__/index.spec.js.snap
+++ b/test/__snapshots__/index.spec.js.snap
@@ -92,6 +92,108 @@ Object {
 }
 `;
 
+exports[`HTTP -> http request makes a DELETE request to baseURL + path using the request method 1`] = `
+Object {
+  "data": Object {
+    "foo": "bar",
+  },
+  "headers": Headers {
+    "_headers": Object {
+      "content-type": Array [
+        "application/json",
+      ],
+    },
+  },
+  "status": 200,
+  "statusText": "OK",
+}
+`;
+
+exports[`HTTP -> http request makes a GET request to baseURL + path using the request method 1`] = `
+Object {
+  "data": Object {
+    "foo": "bar",
+  },
+  "headers": Headers {
+    "_headers": Object {
+      "content-type": Array [
+        "application/json",
+      ],
+    },
+  },
+  "status": 200,
+  "statusText": "OK",
+}
+`;
+
+exports[`HTTP -> http request makes a HEAD request to baseURL + path using the request method 1`] = `
+Object {
+  "data": Object {
+    "foo": "bar",
+  },
+  "headers": Headers {
+    "_headers": Object {
+      "content-type": Array [
+        "application/json",
+      ],
+    },
+  },
+  "status": 200,
+  "statusText": "OK",
+}
+`;
+
+exports[`HTTP -> http request makes a PATCH request to baseURL + path using the request method 1`] = `
+Object {
+  "data": Object {
+    "foo": "bar",
+  },
+  "headers": Headers {
+    "_headers": Object {
+      "content-type": Array [
+        "application/json",
+      ],
+    },
+  },
+  "status": 200,
+  "statusText": "OK",
+}
+`;
+
+exports[`HTTP -> http request makes a POST request to baseURL + path using the request method 1`] = `
+Object {
+  "data": Object {
+    "foo": "bar",
+  },
+  "headers": Headers {
+    "_headers": Object {
+      "content-type": Array [
+        "application/json",
+      ],
+    },
+  },
+  "status": 200,
+  "statusText": "OK",
+}
+`;
+
+exports[`HTTP -> http request makes a PUT request to baseURL + path using the request method 1`] = `
+Object {
+  "data": Object {
+    "foo": "bar",
+  },
+  "headers": Headers {
+    "_headers": Object {
+      "content-type": Array [
+        "application/json",
+      ],
+    },
+  },
+  "status": 200,
+  "statusText": "OK",
+}
+`;
+
 exports[`HTTP -> http response not ok gets rejected 1`] = `[Error: Not Found]`;
 
 exports[`trae defaults returns the current default config when no params are passed 1`] = `

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -241,31 +241,182 @@ describe('HTTP -> http', () => {
       fetchMock.restore();
     });
 
-    ['get', 'delete', 'head', 'post', 'put', 'patch'].forEach((method) => {
-      it(`makes a ${method.toUpperCase()} request to baseURL + path using the request method`, () => {
-        const url = `${TEST_URL}/foo`;
+    it('makes a GET request to baseURL + path using the request method', () => {
+      const url = `${TEST_URL}/foo`;
 
-        fetchMock.mock(url, {
-          status : 200,
-          body   : {
-            foo: 'bar'
-          },
-          headers: {
-            'Content-Type': 'application/json'
-          }
-        }, {
-          method
-        });
+      fetchMock.mock(`${url}?foo=sar&bar=test`, {
+        status : 200,
+        body   : {
+          foo: 'bar'
+        },
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }, {
+        method: 'get'
+      });
 
-        return trae.request({ url, method, foo: 'bar' })
-        .then((res) => {
-          expect(res).toMatchSnapshot();
-          expect(fetchMock.called(url)).toBeTruthy();
-          expect(fetchMock.lastUrl()).toBe(url);
-          expect(fetchMock.lastOptions().method).toBe(method);
-        });
+      return trae.request({
+        url,
+        method: 'get',
+        params: {
+          foo: 'sar',
+          bar: 'test'
+        }
+      })
+      .then((res) => {
+        expect(res).toMatchSnapshot();
+        expect(fetchMock.called(`${url}?foo=sar&bar=test`)).toBeTruthy();
+        expect(fetchMock.lastUrl()).toBe(`${url}?foo=sar&bar=test`);
+        expect(fetchMock.lastOptions().method).toBe('get');
+      });
+    });
+
+    it('makes a POST request to baseURL + path using the request method', () => {
+      const url = `${TEST_URL}/foo`;
+
+      fetchMock.mock(url, {
+        status : 200,
+        body   : {
+          foo: 'bar'
+        },
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }, {
+        method: 'post'
+      });
+
+      return trae.request({
+        url,
+        method: 'post',
+        body  : {
+          foo: 'baz'
+        }
+      })
+      .then((res) => {
+        expect(res).toMatchSnapshot();
+        expect(fetchMock.called(url)).toBeTruthy();
+        expect(fetchMock.lastUrl()).toBe(url);
+        expect(fetchMock.lastOptions().method).toBe('post');
+      });
+    });
+
+    it('makes a PUT request to baseURL + path using the request method', () => {
+      const url = `${TEST_URL}/foo`;
+
+      fetchMock.mock(url, {
+        status : 200,
+        body   : {
+          foo: 'bar'
+        },
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }, {
+        method: 'put'
+      });
+
+      return trae.request({
+        url,
+        method: 'put',
+        body  : {
+          foo: 'bar'
+        }
+      })
+      .then((res) => {
+        expect(res).toMatchSnapshot();
+        expect(fetchMock.called(url)).toBeTruthy();
+        expect(fetchMock.lastUrl()).toBe(url);
+        expect(fetchMock.lastOptions().method).toBe('put');
+      });
+    });
+
+    it('makes a PATCH request to baseURL + path using the request method', () => {
+      const url = `${TEST_URL}/foo`;
+
+      fetchMock.mock(url, {
+        status : 200,
+        body   : {
+          foo: 'bar'
+        },
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }, {
+        method: 'patch'
+      });
+
+      return trae.request({
+        url,
+        method: 'patch',
+        body  : {
+          foo: 'bar'
+        }
+      })
+      .then((res) => {
+        expect(res).toMatchSnapshot();
+        expect(fetchMock.called(url)).toBeTruthy();
+        expect(fetchMock.lastUrl()).toBe(url);
+        expect(fetchMock.lastOptions().method).toBe('patch');
+      });
+    });
+
+    it('makes a DELETE request to baseURL + path using the request method', () => {
+      const url = `${TEST_URL}/foo`;
+
+      fetchMock.mock(url, {
+        status : 200,
+        body   : {
+          foo: 'bar'
+        },
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }, {
+        method: 'delete'
+      });
+
+      return trae.request({
+        url,
+        method: 'delete',
+        body  : {
+          baz: 'foo'
+        }
+      })
+      .then((res) => {
+        expect(res).toMatchSnapshot();
+        expect(fetchMock.called(url)).toBeTruthy();
+        expect(fetchMock.lastUrl()).toBe(url);
+        expect(fetchMock.lastOptions().method).toBe('delete');
+      });
+    });
+
+    it('makes a HEAD request to baseURL + path using the request method', () => {
+      const url = `${TEST_URL}/foo`;
+
+      fetchMock.mock(url, {
+        status : 200,
+        body   : {
+          foo: 'bar'
+        },
+        headers: {
+          'Content-Type': 'application/json'
+        }
+      }, {
+        method: 'head'
+      });
+
+      return trae.request({
+        url,
+        method: 'head'
+      })
+      .then((res) => {
+        expect(res).toMatchSnapshot();
+        expect(fetchMock.called(url)).toBeTruthy();
+        expect(fetchMock.lastUrl()).toBe(url);
+        expect(fetchMock.lastOptions().method).toBe('head');
       });
     });
   });
-
 });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -91,7 +91,7 @@ describe('HTTP -> http', () => {
 
   describe('get', () => {
     it('makes a GET request to baseURL + path', () => {
-      const url  = `${TEST_URL}/foo`;
+      const url = `${TEST_URL}/foo`;
 
       fetchMock.mock(url, {
         status : 200,
@@ -115,7 +115,7 @@ describe('HTTP -> http', () => {
 
   describe('del', () => {
     it('makes a DELETE request to baseURL + path', () => {
-      const url  = `${TEST_URL}/foo`;
+      const url = `${TEST_URL}/foo`;
 
       fetchMock.mock(url, {
         status : 200,
@@ -139,7 +139,7 @@ describe('HTTP -> http', () => {
 
   describe('head', () => {
     it('makes a HEAD request to baseURL + path', () => {
-      const url  = `${TEST_URL}/foo`;
+      const url = `${TEST_URL}/foo`;
 
       fetchMock.mock(url, {
         status: 200
@@ -159,11 +159,13 @@ describe('HTTP -> http', () => {
 
   describe('post', () => {
     it('makes a POST request to baseURL + path', () => {
-      const url  = `${TEST_URL}/foo`;
+      const url = `${TEST_URL}/foo`;
 
       fetchMock.mock(url, {
         status : 200,
-        body   : { foo: 'bar' },
+        body   : {
+          foo: 'bar'
+        },
         headers: {
           'Content-Type': 'application/json'
         }
@@ -183,11 +185,13 @@ describe('HTTP -> http', () => {
 
   describe('put', () => {
     it('makes a PUT request to baseURL + path', () => {
-      const url  = `${TEST_URL}/foo`;
+      const url = `${TEST_URL}/foo`;
 
       fetchMock.mock(url, {
         status : 200,
-        body   : { foo: 'bar' },
+        body   : {
+          foo: 'bar'
+        },
         headers: {
           'Content-Type': 'application/json'
         }
@@ -207,11 +211,13 @@ describe('HTTP -> http', () => {
 
   describe('patch', () => {
     it('makes a PATCH request to baseURL + path', () => {
-      const url  = `${TEST_URL}/foo`;
+      const url = `${TEST_URL}/foo`;
 
       fetchMock.mock(url, {
         status : 200,
-        body   : { foo: 'bar' },
+        body   : {
+          foo: 'bar'
+        },
         headers: {
           'Content-Type': 'application/json'
         }
@@ -225,6 +231,39 @@ describe('HTTP -> http', () => {
         expect(fetchMock.called(url)).toBeTruthy();
         expect(fetchMock.lastUrl()).toBe(url);
         expect(fetchMock.lastOptions().method).toBe('patch');
+      });
+    });
+  });
+
+  describe('request', () => {
+
+    afterEach(() => {
+      fetchMock.restore();
+    });
+
+    ['get', 'delete', 'head', 'post', 'put', 'patch'].forEach((method) => {
+      it(`makes a ${method.toUpperCase()} request to baseURL + path using the request method`, () => {
+        const url = `${TEST_URL}/foo`;
+
+        fetchMock.mock(url, {
+          status : 200,
+          body   : {
+            foo: 'bar'
+          },
+          headers: {
+            'Content-Type': 'application/json'
+          }
+        }, {
+          method
+        });
+
+        return trae.request({ url, method, foo: 'bar' })
+        .then((res) => {
+          expect(res).toMatchSnapshot();
+          expect(fetchMock.called(url)).toBeTruthy();
+          expect(fetchMock.lastUrl()).toBe(url);
+          expect(fetchMock.lastOptions().method).toBe(method);
+        });
       });
     });
   });


### PR DESCRIPTION
This PR adds the `request` method to use like the following example:

```JavaScript
trae.request({
  method: 'get',
  url: 'https://foo/bar',
  mode: 'no-cors',
  credentials: 'same-origin'
});