### PR TITLE
Add defaults inheritances when creating instances.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@ import query from 'trae-query';
 
 import Middleware      from './middleware';
 import Config          from './config';
-import { skip }        from './utils';
+import { skip, merge } from './utils';
 import { format }      from './helpers/url-handler';
 import responseHandler from './helpers/response-handler';
 
@@ -20,7 +20,7 @@ class Trae {
   }
 
   create(config) {
-    return new this.constructor(config);
+    return new this.constructor(merge(this.defaults(), config));
   }
 
   defaults(config) {

--- a/test/trae/create.spec.js
+++ b/test/trae/create.spec.js
@@ -1,11 +1,24 @@
 /* global describe it expect */
 import trae from '../../lib';
 
-
 describe('trae - create', () => {
   it('returns a new instance of Trae with the provided config as defaults', () => {
     const apiFoo = trae.create({ baseUrl: '/api/foo' });
     expect(apiFoo._baseUrl).toBe('/api/foo');
     expect(apiFoo._middleware).toBeDefined();
+  });
+
+  it('inherits the defaults from the previous instances', () => {
+    trae.baseUrl('/api/foo');
+    trae.defaults({ mode: 'no-cors' });
+    const apiFoo = trae.create();
+    expect(apiFoo._baseUrl).toBe('/api/foo');
+    expect(apiFoo.defaults().mode).toBe('no-cors');
+
+    apiFoo.defaults({ bodyType: 'buffer' });
+    const apiFoo2 = apiFoo.create();
+    expect(apiFoo2._baseUrl).toBe('/api/foo');
+    expect(apiFoo2.defaults().mode).toBe('no-cors');
+    expect(apiFoo2.defaults().bodyType).toBe('buffer');
   });
 });

--- a/test/trae/create.spec.js
+++ b/test/trae/create.spec.js
@@ -21,4 +21,12 @@ describe('trae - create', () => {
     expect(apiFoo2.defaults().mode).toBe('no-cors');
     expect(apiFoo2.defaults().bodyType).toBe('buffer');
   });
+
+  it('provided config values override the inherited ones', () => {
+    trae.baseUrl('/api/foo');
+    trae.defaults({ mode: 'cache' });
+    const apiBar = trae.create({ baseUrl: '/api/bar', mode: 'no-cors' });
+    expect(apiBar._baseUrl).toBe('/api/bar');
+    expect(apiBar.defaults().mode).toBe('no-cors');
+  });
 });


### PR DESCRIPTION
When using `trae.create` the new instance will inherit the `defaults` from the creator.

```js
trae.defaults({ mode: 'no-cors' });
const apiFoo = trae.create();

apiFoo.defaults().mode // => no-cors
```