### PR TITLE
Improve helper

### DIFF
--- a/lib/helpers/url-handler.js
+++ b/lib/helpers/url-handler.js
@@ -12,7 +12,8 @@ export function concatParams(URL, params) {
   if (!params) {
     return URL;
   }
-  return `${URL}?${stringifyParams(params)}`;
+
+  return `${URL}?${stringifyParams(params)}`.replace(/\?$/, '');
 }
 
 /**

--- a/test/helpers.url-handler.spec.js
+++ b/test/helpers.url-handler.spec.js
@@ -15,7 +15,13 @@ describe('urlHandler', () => {
         }
       };
 
-      expect(concatParams(url, params)).toEqual('https://www.foo.com/bar?foo%5Bbar%5D%5Bbaz%5D=foobarbaz');
+      expect(concatParams(url, params))
+      .toBe('https://www.foo.com/bar?foo%5Bbar%5D%5Bbaz%5D=foobarbaz');
+    });
+
+    it('when params are an empty object it returns the same url', () => {
+      const url = 'https://www.foo.com/bar';
+      expect(concatParams(url, {})).toBe(url);
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3351,6 +3351,10 @@ qs@6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.2.0.tgz#3b7848c03c2dece69a9522b0fae8c4126d745f3b"
 
+qs@^6.3.0, qs@~6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.0.tgz#f403b264f23bc01228c74131b407f18d5ea5d442"
+
 qs@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/qs/-/qs-2.3.3.tgz#e9e85adbe75da0bbe4c8e0476a086290f863b404"
@@ -3358,10 +3362,6 @@ qs@~2.3.3:
 qs@~6.2.0:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.2.1.tgz#ce03c5ff0935bc1d9d69a9f14cbd18e568d67625"
-
-qs@~6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.0.tgz#f403b264f23bc01228c74131b407f18d5ea5d442"
 
 randomatic@^1.1.3:
   version "1.1.6"
@@ -4109,10 +4109,6 @@ tough-cookie@^2.3.1, tough-cookie@~2.3.0:
 tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
-
-trae-query@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/trae-query/-/trae-query-0.1.1.tgz#961d66b898a9f9b638055a2c3d447f4009f67ce2"
 
 trim-newlines@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
`concatParams` url helper no longer adds a `?` at the end of the url when the params is an empty object.