### PR TITLE
Rework Config class

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,8 +105,7 @@ The configuration object can be used in all request methods, the following attri
 
   // The Headers object associated with the request
   headers: {
-    'Accept': 'application/json, text/plain, */*', // Default
-    'Content-Type': 'application/json' // Default
+    'Content-Type': 'application/json' // Default header for methods with body (patch, post & put)
     'X-My-Custom-Header': 'foo-bar'
   },
 
@@ -147,6 +146,27 @@ When called with no params acts as a getter, returning the defined defaults.
 ```js
 const config = trae.defaults();
 ```
+
+It is possible to set default configuration for specific methods passing an
+object with the method as key:
+
+```js
+trae.defaults({
+  post: {
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded'
+    }
+  }
+});
+```
+
+#### Request configuration precedence
+
+The configuration for a request will be merged following this precedence rules, each level overrides the followings:
+
+  1. Request params config.
+  1. Method config set with `trae.defaults({ [method]: { ... } })`.
+  1. Trae config set with `trae.defaults({ ... })`.
 
 #### `trae.baseUrl([url])`
 
@@ -246,7 +266,6 @@ const apiFoo = api.create()
 
 apiFoo.defaults() // { mode: 'no-cors', ... }
 ```
-
 
 [⬆ back to top](#content)
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,14 +1,9 @@
 import { merge } from './utils';
 
 
-const DEFAULT_HEADERS = {
-  'Accept'      : 'application/json, text/plain, */*', // eslint-disable-line quote-props
-  'Content-Type': 'application/json'
-};
-
 export default class Config {
   constructor(config = {}) {
-    this._defaults = merge({}, { headers: DEFAULT_HEADERS });
+    this._defaults = { headers: {} };
     this._config   = {};
 
     this.set(config);

--- a/lib/config.js
+++ b/lib/config.js
@@ -3,8 +3,7 @@ import { merge, skip } from './utils';
 
 export default class Config {
   constructor(config = {}) {
-    this._defaults = { headers: {} };
-    this._config   = {};
+    this._config   = { headers: {} };
 
     this.set(config);
   }
@@ -13,7 +12,6 @@ export default class Config {
     const params = merge(...configParams);
 
     const config = merge(
-      this._defaults, 
       this.skipNotUsedMethods(params.method),
       this._config[params.method], 
       params
@@ -41,6 +39,6 @@ export default class Config {
   }
 
   get() {
-    return merge(this._defaults, this._config);
+    return merge(this._config);
   }
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,4 +1,4 @@
-import { merge } from './utils';
+import { merge, skip } from './utils';
 
 
 export default class Config {
@@ -10,7 +10,15 @@ export default class Config {
   }
 
   mergeWithDefaults(...configParams) {
-    const config = merge(this._defaults, this._config, ...configParams);
+    const params = merge(...configParams);
+
+    const config = merge(
+      this._defaults, 
+      this.skipNotUsedMethods(params.method),
+      this._config[params.method], 
+      params
+    );
+
     if (
       typeof config.body === 'object' &&
       config.headers &&
@@ -20,7 +28,14 @@ export default class Config {
     }
     return config;
   }
+  
+  skipNotUsedMethods(currentMethod){
+    const notUsedMethods = [ 'delete', 'get', 'head', 'patch', 'post', 'put' ] 
+      .filter(method => currentMethod !== method.toLowerCase());
+    return skip(this._config, notUsedMethods);
+  }
 
+  
   set(config) {
     this._config = merge(this._config, config);
   }

--- a/lib/config.js
+++ b/lib/config.js
@@ -8,12 +8,12 @@ export default class Config {
     this.set(config);
   }
 
-  mergeWithDefaults(...configParams) {
+  merge(...configParams) {
     const params = merge(...configParams);
 
     const config = merge(
       this.skipNotUsedMethods(params.method),
-      this._config[params.method], 
+      this._config[params.method],
       params
     );
 
@@ -26,14 +26,14 @@ export default class Config {
     }
     return config;
   }
-  
-  skipNotUsedMethods(currentMethod){
-    const notUsedMethods = [ 'delete', 'get', 'head', 'patch', 'post', 'put' ] 
+
+  skipNotUsedMethods(currentMethod) {
+    const notUsedMethods = ['delete', 'get', 'head', 'patch', 'post', 'put']
       .filter(method => currentMethod !== method.toLowerCase());
     return skip(this._config, notUsedMethods);
   }
 
-  
+
   set(config) {
     this._config = merge(this._config, config);
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -48,7 +48,7 @@ class Trae {
 
   request(config = {}) {
     config.method || (config.method = 'get');
-    const mergedConfig = this._config.mergeWithDefaults(config);
+    const mergedConfig = this._config.merge(config);
     const url          = formatUrl(this._baseUrl, config.url, config.params);
 
     return this._fetch(url, mergedConfig);
@@ -71,7 +71,7 @@ class Trae {
   _initMethodsWithNoBody() {
     ['get', 'delete', 'head'].forEach((method) => {
       this[method] = (path, config = {}) => {
-        const mergedConfig = this._config.mergeWithDefaults(config, { method });
+        const mergedConfig = this._config.merge(config, { method });
         const url          = formatUrl(this._baseUrl, path, config.params);
 
         return this._fetch(url, mergedConfig);
@@ -86,7 +86,7 @@ class Trae {
       this._config.set({ [method]: defaultConf });
 
       this[method] = (path, body, config) => {
-        const mergedConfig = this._config.mergeWithDefaults(config, { body, method });
+        const mergedConfig = this._config.merge(config, { body, method });
         const url          = formatUrl(this._baseUrl, path);
 
         return this._fetch(url, mergedConfig);

--- a/lib/index.js
+++ b/lib/index.js
@@ -80,7 +80,11 @@ class Trae {
   }
 
   _initMethodsWithBody() {
+    const defaultConf = { headers: { 'Contet-Type': 'application/json' } };
+
     ['post', 'put', 'patch'].forEach((method) => {
+      this._config.set({ [method]: defaultConf });
+
       this[method] = (path, body, config) => {
         const mergedConfig = this._config.mergeWithDefaults(config, { body, method });
         const url          = formatUrl(this._baseUrl, path);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,11 +19,12 @@ export function merge(...params)  {
  * @return {Object} the object with the properties skipped
  */
 export function skip(obj, keys) {
-  const skipped = {};
-  Object.keys(obj).forEach((objKey) => {
-    if (keys.indexOf(objKey) === -1) {
-      skipped[objKey] = obj[objKey];
-    }
-  });
-  return skipped;
+  const result = {}
+  Object.keys(obj)
+    .filter(key => !keys.includes(key))
+    .forEach(key => {
+      result[key] = obj[key];
+    })
+  return result;
 }
+

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,12 +19,12 @@ export function merge(...params)  {
  * @return {Object} the object with the properties skipped
  */
 export function skip(obj, keys) {
-  const result = {}
+  const result = {};
   Object.keys(obj)
     .filter(key => !keys.includes(key))
-    .forEach(key => {
+    .forEach((key) => {
       result[key] = obj[key];
-    })
+    });
   return result;
 }
 

--- a/test/__snapshots__/config.spec.js.snap
+++ b/test/__snapshots__/config.spec.js.snap
@@ -2,8 +2,6 @@ exports[`Config -> config get returns the merged _defaults and _config 1`] = `
 Object {
   "credentials": "same-origin",
   "headers": Object {
-    "Accept": "application/json, text/plain, */*",
-    "Content-Type": "application/json",
     "X-ACCESS-TOKE": "aasdljhf2kjrasdf2l3jrhn2",
   },
   "mode": "cors",
@@ -13,7 +11,6 @@ Object {
 exports[`Config -> config mergeWithDefaults does not mutate _config or _defaults 1`] = `
 Object {
   "headers": Object {
-    "Accept": "application/json, text/plain, */*",
     "Content-Type": "text/plain",
   },
   "mode": "cors",
@@ -24,7 +21,6 @@ exports[`Config -> config mergeWithDefaults merges all the params passed 1`] = `
 Object {
   "credentials": "same-origin",
   "headers": Object {
-    "Accept": "application/json, text/plain, */*",
     "Content-Type": "text/plain",
   },
   "mode": "no-cors",
@@ -33,21 +29,17 @@ Object {
 
 exports[`Config -> config mergeWithDefaults returns body stringified according to Content-Type 1`] = `
 Object {
-  "body": "{\"foo\":\"bar\"}",
-  "headers": Object {
-    "Accept": "application/json, text/plain, */*",
-    "Content-Type": "application/json",
+  "body": Object {
+    "foo": "bar",
   },
+  "headers": Object {},
 }
 `;
 
 exports[`Config -> config mergeWithDefaults returns the config merged with the params 1`] = `
 Object {
   "credentials": "same-origin",
-  "headers": Object {
-    "Accept": "application/json, text/plain, */*",
-    "Content-Type": "application/json",
-  },
+  "headers": Object {},
   "mode": "no-cors",
 }
 `;
@@ -55,10 +47,7 @@ Object {
 exports[`Config -> config mergeWithDefaults returns the config merged with the params 2`] = `
 Object {
   "credentials": "same-origin",
-  "headers": Object {
-    "Accept": "application/json, text/plain, */*",
-    "Content-Type": "application/json",
-  },
+  "headers": Object {},
   "mode": "no-cors",
 }
 `;

--- a/test/__snapshots__/config.spec.js.snap
+++ b/test/__snapshots__/config.spec.js.snap
@@ -8,7 +8,7 @@ Object {
 }
 `;
 
-exports[`Config -> config mergeWithDefaults does not mutate _config or _defaults 1`] = `
+exports[`Config -> config merge does not mutate _config or _defaults 1`] = `
 Object {
   "headers": Object {
     "Content-Type": "text/plain",
@@ -17,7 +17,7 @@ Object {
 }
 `;
 
-exports[`Config -> config mergeWithDefaults merges all the params passed 1`] = `
+exports[`Config -> config merge merges all the params passed 1`] = `
 Object {
   "credentials": "same-origin",
   "headers": Object {
@@ -27,7 +27,7 @@ Object {
 }
 `;
 
-exports[`Config -> config mergeWithDefaults returns body stringified according to Content-Type 1`] = `
+exports[`Config -> config merge returns body stringified according to Content-Type 1`] = `
 Object {
   "body": Object {
     "foo": "bar",
@@ -36,7 +36,7 @@ Object {
 }
 `;
 
-exports[`Config -> config mergeWithDefaults returns the config merged with the params 1`] = `
+exports[`Config -> config merge returns the config merged with the params 1`] = `
 Object {
   "credentials": "same-origin",
   "headers": Object {},
@@ -44,7 +44,7 @@ Object {
 }
 `;
 
-exports[`Config -> config mergeWithDefaults returns the config merged with the params 2`] = `
+exports[`Config -> config merge returns the config merged with the params 2`] = `
 Object {
   "credentials": "same-origin",
   "headers": Object {},

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -61,33 +61,33 @@ describe('Config -> config', () => {
 
   });
 
-  describe('mergeWithDefaults', () => {
+  describe('merge', () => {
 
     it('returns body stringified according to Content-Type', () => {
       const config = new Config();
 
-      const actual = config.mergeWithDefaults({ body: { foo: 'bar' } });
+      const actual = config.merge({ body: { foo: 'bar' } });
       expect(actual).toMatchSnapshot();
     });
 
     it('returns the config merged with the params', () => {
       const config = new Config({ mode: 'no-cors' });
 
-      const actual = config.mergeWithDefaults({ credentials: 'same-origin' });
+      const actual = config.merge({ credentials: 'same-origin' });
       expect(actual).toMatchSnapshot();
     });
 
     it('returns the config merged with the params', () => {
       const config = new Config({ mode: 'no-cors' });
 
-      const actual = config.mergeWithDefaults({ credentials: 'same-origin' });
+      const actual = config.merge({ credentials: 'same-origin' });
       expect(actual).toMatchSnapshot();
     });
 
     it('merges all the params passed', () => {
       const config = new Config({ mode: 'no-cors' });
 
-      const actual = config.mergeWithDefaults(
+      const actual = config.merge(
         { credentials: 'same-origin' },
         { headers: { 'Content-Type': 'text/plain' } }
       );
@@ -99,7 +99,7 @@ describe('Config -> config', () => {
 
       expect(config._config).toEqual({ headers: {}, mode: 'no-cors' });
 
-      const actual = config.mergeWithDefaults(
+      const actual = config.merge(
         { headers: { 'Content-Type': 'text/plain' } },
         { mode: 'cors' }
       );

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -19,16 +19,13 @@ describe('Config -> config', () => {
   it('initializes with the default fetch config', () => {
     const config = new Config();
 
-    expect(config._config).toEqual({});
-    expect(config._defaults).toEqual(defaults);
+    expect(config._config).toEqual(defaults);
     expect(config.get()).toEqual(defaults);
   });
 
   it('initializes with the defaults merged with the provided config', () => {
     const config = getConfigWithParams();
 
-    expect(config._config).toEqual(configParams);
-    expect(config._defaults).toEqual(defaults);
     expect(config.get()).toEqual(merge(defaults, configParams));
   });
 
@@ -100,8 +97,7 @@ describe('Config -> config', () => {
     it('does not mutate _config or _defaults', () => {
       const config = new Config({ mode: 'no-cors' });
 
-      expect(config._config).toEqual({ mode: 'no-cors' });
-      expect(config._defaults).toEqual(defaults);
+      expect(config._config).toEqual({ headers: {}, mode: 'no-cors' });
 
       const actual = config.mergeWithDefaults(
         { headers: { 'Content-Type': 'text/plain' } },
@@ -109,8 +105,7 @@ describe('Config -> config', () => {
       );
       expect(actual).toMatchSnapshot();
 
-      expect(config._config).toEqual({ mode: 'no-cors' });
-      expect(config._defaults).toEqual(defaults);
+      expect(config._config).toEqual({ headers: {}, mode: 'no-cors' });
     });
 
   });

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -4,12 +4,7 @@ import { merge } from '../lib/utils';
 import Config    from '../lib/config';
 
 
-const DEFAULT_HEADERS = {
-  Accept        : 'application/json, text/plain, */*',
-  'Content-Type': 'application/json'
-};
-
-const defaults = merge({}, { headers: DEFAULT_HEADERS });
+const defaults = { headers: {} };
 
 const configParams = {
   mode       : 'no-cors',

--- a/test/trae/__snapshots__/constructor.spec.js.snap
+++ b/test/trae/__snapshots__/constructor.spec.js.snap
@@ -1,0 +1,23 @@
+exports[`trae adds "Content-Type": "application/json" header to the methods with body 1`] = `
+Object {
+  "headers": Object {
+    "Contet-Type": "application/json",
+  },
+}
+`;
+
+exports[`trae adds "Content-Type": "application/json" header to the methods with body 2`] = `
+Object {
+  "headers": Object {
+    "Contet-Type": "application/json",
+  },
+}
+`;
+
+exports[`trae adds "Content-Type": "application/json" header to the methods with body 3`] = `
+Object {
+  "headers": Object {
+    "Contet-Type": "application/json",
+  },
+}
+`;

--- a/test/trae/__snapshots__/defaults.spec.js.snap
+++ b/test/trae/__snapshots__/defaults.spec.js.snap
@@ -1,6 +1,21 @@
 exports[`trae -> defaults returns the current default config when no params are passed 1`] = `
 Object {
   "headers": Object {},
+  "patch": Object {
+    "headers": Object {
+      "Contet-Type": "application/json",
+    },
+  },
+  "post": Object {
+    "headers": Object {
+      "Contet-Type": "application/json",
+    },
+  },
+  "put": Object {
+    "headers": Object {
+      "Contet-Type": "application/json",
+    },
+  },
 }
 `;
 
@@ -9,5 +24,20 @@ Object {
   "credentials": "same-origin",
   "headers": Object {},
   "mode": "no-cors",
+  "patch": Object {
+    "headers": Object {
+      "Contet-Type": "application/json",
+    },
+  },
+  "post": Object {
+    "headers": Object {
+      "Contet-Type": "application/json",
+    },
+  },
+  "put": Object {
+    "headers": Object {
+      "Contet-Type": "application/json",
+    },
+  },
 }
 `;

--- a/test/trae/__snapshots__/defaults.spec.js.snap
+++ b/test/trae/__snapshots__/defaults.spec.js.snap
@@ -1,19 +1,13 @@
 exports[`trae -> defaults returns the current default config when no params are passed 1`] = `
 Object {
-  "headers": Object {
-    "Accept": "application/json, text/plain, */*",
-    "Content-Type": "application/json",
-  },
+  "headers": Object {},
 }
 `;
 
 exports[`trae -> defaults sets the default config to be used on all requests for the instance 1`] = `
 Object {
   "credentials": "same-origin",
-  "headers": Object {
-    "Accept": "application/json, text/plain, */*",
-    "Content-Type": "application/json",
-  },
+  "headers": Object {},
   "mode": "no-cors",
 }
 `;

--- a/test/trae/__snapshots__/patch.spec.js.snap
+++ b/test/trae/__snapshots__/patch.spec.js.snap
@@ -1,5 +1,11 @@
 exports[`trae -> patch makes a PATCH request to baseURL + path 1`] = `
 Object {
+  "Contet-Type": "application/json",
+}
+`;
+
+exports[`trae -> patch makes a PATCH request to baseURL + path 2`] = `
+Object {
   "data": Object {
     "foo": "bar",
   },

--- a/test/trae/__snapshots__/post.spec.js.snap
+++ b/test/trae/__snapshots__/post.spec.js.snap
@@ -1,5 +1,11 @@
 exports[`trae -> post makes a POST request to baseURL + path 1`] = `
 Object {
+  "Contet-Type": "application/json",
+}
+`;
+
+exports[`trae -> post makes a POST request to baseURL + path 2`] = `
+Object {
   "data": Object {
     "foo": "bar",
   },

--- a/test/trae/__snapshots__/put.spec.js.snap
+++ b/test/trae/__snapshots__/put.spec.js.snap
@@ -1,5 +1,11 @@
 exports[`trae -> put makes a PUT request to baseURL + path 1`] = `
 Object {
+  "Contet-Type": "application/json",
+}
+`;
+
+exports[`trae -> put makes a PUT request to baseURL + path 2`] = `
+Object {
   "data": Object {
     "foo": "bar",
   },

--- a/test/trae/constructor.spec.js
+++ b/test/trae/constructor.spec.js
@@ -8,4 +8,14 @@ describe('trae', () => {
     expect(trae._middleware).toBeDefined();
     expect(trae._config).toBeDefined();
   });
+
+  it('adds "Content-Type": "application/json" header to the methods with body', () => {
+    expect(trae.defaults().post).toMatchSnapshot();
+    expect(trae.defaults().patch).toMatchSnapshot();
+    expect(trae.defaults().put).toMatchSnapshot();
+
+    expect(trae.defaults().head).toBe(undefined);
+    expect(trae.defaults().get).toBe(undefined);
+    expect(trae.defaults().delete).toBe(undefined);
+  });
 });

--- a/test/trae/delete.spec.js
+++ b/test/trae/delete.spec.js
@@ -22,8 +22,16 @@ describe('trae -> delete', () => {
     }, {
       method: 'delete'
     });
+    
+    const testTrae = trae.create();
 
-    return trae.delete(url)
+    testTrae.before(c => {
+      expect(c.headers).toEqual({});
+      return c
+    })
+
+
+    return testTrae.delete(url)
     .then((res) => {
       expect(res).toMatchSnapshot();
       expect(fetchMock.called(url)).toBeTruthy();

--- a/test/trae/delete.spec.js
+++ b/test/trae/delete.spec.js
@@ -22,13 +22,13 @@ describe('trae -> delete', () => {
     }, {
       method: 'delete'
     });
-    
+
     const testTrae = trae.create();
 
-    testTrae.before(c => {
+    testTrae.before((c) => {
       expect(c.headers).toEqual({});
-      return c
-    })
+      return c;
+    });
 
 
     return testTrae.delete(url)

--- a/test/trae/get.spec.js
+++ b/test/trae/get.spec.js
@@ -10,6 +10,31 @@ afterEach(() => {
 const TEST_URL = 'http://localhost:8080/api';
 
 describe('trae -> get', () => {
+  it('does not have headers set by defualt', (next) => {
+    const url = `${TEST_URL}/foo`;
+
+    fetchMock.mock(url, {
+      status : 200,
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: {
+        foo: 'bar'
+      }
+    });
+
+    const testTrae = trae.create();
+
+    testTrae.before(c => {
+      expect(c.headers).toEqual({});
+      next();
+      return c;
+    })
+
+
+    return testTrae.get(url);
+  });
+
   it('makes a GET request to baseURL + path', () => {
     const url = `${TEST_URL}/foo`;
 

--- a/test/trae/get.spec.js
+++ b/test/trae/get.spec.js
@@ -25,11 +25,11 @@ describe('trae -> get', () => {
 
     const testTrae = trae.create();
 
-    testTrae.before(c => {
+    testTrae.before((c) => {
       expect(c.headers).toEqual({});
       next();
       return c;
-    })
+    });
 
 
     return testTrae.get(url);

--- a/test/trae/head.spec.js
+++ b/test/trae/head.spec.js
@@ -21,10 +21,10 @@ describe('trae -> head', () => {
 
     const testTrae = trae.create();
 
-    testTrae.before(c => {
+    testTrae.before((c) => {
       expect(c.headers).toEqual({});
       return c;
-    })
+    });
 
 
     return testTrae.head(url)

--- a/test/trae/head.spec.js
+++ b/test/trae/head.spec.js
@@ -19,7 +19,15 @@ describe('trae -> head', () => {
       method: 'head'
     });
 
-    return trae.head(url)
+    const testTrae = trae.create();
+
+    testTrae.before(c => {
+      expect(c.headers).toEqual({});
+      return c;
+    })
+
+
+    return testTrae.head(url)
     .then((res) => {
       expect(res).toMatchSnapshot();
       expect(fetchMock.called(url)).toBeTruthy();

--- a/test/trae/patch.spec.js
+++ b/test/trae/patch.spec.js
@@ -27,10 +27,10 @@ describe('trae -> patch', () => {
 
     const testTrae = trae.create();
 
-    testTrae.before(c => {
+    testTrae.before((c) => {
       expect(c.headers).toMatchSnapshot();
       return c;
-    })
+    });
 
 
     return testTrae.patch(url, { foo: 'bar' })

--- a/test/trae/patch.spec.js
+++ b/test/trae/patch.spec.js
@@ -25,7 +25,15 @@ describe('trae -> patch', () => {
       method: 'patch'
     });
 
-    return trae.patch(url, { foo: 'bar' })
+    const testTrae = trae.create();
+
+    testTrae.before(c => {
+      expect(c.headers).toMatchSnapshot();
+      return c;
+    })
+
+
+    return testTrae.patch(url, { foo: 'bar' })
     .then((res) => {
       expect(res).toMatchSnapshot();
       expect(fetchMock.called(url)).toBeTruthy();

--- a/test/trae/post.spec.js
+++ b/test/trae/post.spec.js
@@ -25,7 +25,15 @@ describe('trae -> post', () => {
       method: 'post'
     });
 
-    return trae.post(url, { foo: 'bar' })
+    const testTrae = trae.create();
+
+    testTrae.before(c => {
+      expect(c.headers).toMatchSnapshot();
+      return c;
+    })
+
+
+    return testTrae.post(url, { foo: 'bar' })
     .then((res) => {
       expect(res).toMatchSnapshot();
       expect(fetchMock.called(url)).toBeTruthy();

--- a/test/trae/post.spec.js
+++ b/test/trae/post.spec.js
@@ -27,10 +27,10 @@ describe('trae -> post', () => {
 
     const testTrae = trae.create();
 
-    testTrae.before(c => {
+    testTrae.before((c) => {
       expect(c.headers).toMatchSnapshot();
       return c;
-    })
+    });
 
 
     return testTrae.post(url, { foo: 'bar' })

--- a/test/trae/put.spec.js
+++ b/test/trae/put.spec.js
@@ -27,10 +27,10 @@ describe('trae -> put', () => {
 
     const testTrae = trae.create();
 
-    testTrae.before(c => {
+    testTrae.before((c) => {
       expect(c.headers).toMatchSnapshot();
       return c;
-    })
+    });
 
 
     return testTrae.put(url, { foo: 'bar' })

--- a/test/trae/put.spec.js
+++ b/test/trae/put.spec.js
@@ -25,7 +25,15 @@ describe('trae -> put', () => {
       method: 'put'
     });
 
-    return trae.put(url, { foo: 'bar' })
+    const testTrae = trae.create();
+
+    testTrae.before(c => {
+      expect(c.headers).toMatchSnapshot();
+      return c;
+    })
+
+
+    return testTrae.put(url, { foo: 'bar' })
     .then((res) => {
       expect(res).toMatchSnapshot();
       expect(fetchMock.called(url)).toBeTruthy();


### PR DESCRIPTION
This PR changes a little bit the way `Config` & `trae.defaults` work

- Now is possible to add config per method, and it will take precedence for that method when being merged on `Config.merge` (previously `Config.mergeWithDefaults`):
```js
trae.defaults({
  post: {
    headers: { 'Content-Type': 'application/json' }
  },
  put: {
    headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
  },
})
```
- Using `{ 'Content-Type': 'application/json' }` as default headers for methods with body (`patch`, `post`, `put`). The methods that don't have a body shouldn't have `Contet-Type` set anyways. #43 