### PR TITLE
Add method with body params support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -82,14 +82,16 @@ class Trae {
   }
 
   _initMethodsWithBody() {
-    const defaultConf = { headers: { 'Content-Type': 'application/json' } };
+    const defaultConf = {
+      headers: { 'Content-Type': 'application/json' }
+    };
 
     ['post', 'put', 'patch'].forEach((method) => {
       this._config.set({ [method]: defaultConf });
 
-      this[method] = (path, body, config) => {
+      this[method] = (path, body = {}, config = {}) => {
         const mergedConfig = this._config.merge(config, { body, method });
-        const url          = formatUrl(this._baseUrl, path);
+        const url          = formatUrl(this._baseUrl, path, config.params);
 
         return this._fetch(url, mergedConfig);
       };

--- a/test/trae/__snapshots__/post.spec.js.snap
+++ b/test/trae/__snapshots__/post.spec.js.snap
@@ -22,3 +22,37 @@ Object {
   "statusText": "OK",
 }
 `;
+
+exports[`trae -> post post -> params makes a POST request to baseURL + path using a nested object as params 1`] = `
+Object {
+  "data": Object {
+    "foo": "bar",
+  },
+  "headers": Headers {
+    "_headers": Object {
+      "content-type": Array [
+        "application/json",
+      ],
+    },
+  },
+  "status": 200,
+  "statusText": "OK",
+}
+`;
+
+exports[`trae -> post post -> params makes a POST request to baseURL + path using params 1`] = `
+Object {
+  "data": Object {
+    "foo": "bar",
+  },
+  "headers": Headers {
+    "_headers": Object {
+      "content-type": Array [
+        "application/json",
+      ],
+    },
+  },
+  "status": 200,
+  "statusText": "OK",
+}
+`;

--- a/test/trae/post.spec.js
+++ b/test/trae/post.spec.js
@@ -14,8 +14,8 @@ describe('trae -> post', () => {
     const url = `${TEST_URL}/foo`;
 
     fetchMock.mock(url, {
-      status : 200,
-      body   : {
+      status: 200,
+      body  : {
         foo: 'bar'
       },
       headers: {
@@ -39,6 +39,77 @@ describe('trae -> post', () => {
       expect(fetchMock.called(url)).toBeTruthy();
       expect(fetchMock.lastUrl()).toBe(url);
       expect(fetchMock.lastOptions().method).toBe('post');
+    });
+  });
+
+  describe('post -> params', () => {
+
+    afterEach(() => {
+      fetchMock.restore();
+    });
+
+    it('makes a POST request to baseURL + path using params', () => {
+      const url = `${TEST_URL}/foo`;
+      const qs  = '?foo=bar&key=123&token=12345lkjhpor837';
+
+      fetchMock.mock(url + qs, {
+        status : 200,
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: {
+          foo: 'bar'
+        }
+      }, {
+        method: 'post'
+      });
+
+      return trae.post(url, {
+        sarasa: 'request body'
+      }, {
+        params: {
+          foo  : 'bar',
+          key  : 123,
+          token: '12345lkjhpor837'
+        }
+      })
+      .then((res) => {
+        expect(res).toMatchSnapshot();
+        expect(fetchMock.called(url + qs)).toBeTruthy();
+        expect(fetchMock.lastUrl()).toBe(url + qs);
+        expect(fetchMock.lastOptions().method).toBe('post');
+      });
+    });
+
+    it('makes a POST request to baseURL + path using a nested object as params', () => {
+      const url = `${TEST_URL}/foo`;
+      const qs  = '?a%5Bb%5D=c';
+
+      fetchMock.mock(url + qs, {
+        status : 200,
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: {
+          foo: 'bar'
+        }
+      });
+
+      return trae.post(url, {
+        sarasa: 'request body'
+      }, {
+        params: {
+          a: {
+            b: 'c'
+          }
+        }
+      })
+      .then((res) => {
+        expect(res).toMatchSnapshot();
+        expect(fetchMock.called(url + qs)).toBeTruthy();
+        expect(fetchMock.lastUrl()).toBe(url + qs);
+        expect(fetchMock.lastOptions().method).toBe('post');
+      });
     });
   });
 });


### PR DESCRIPTION
This PR adds params support to `post`, `put` and `patch` methods.