### PR TITLE
Uppercase methods when calling fetch

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -54,7 +54,8 @@ class Trae {
     return this._fetch(url, mergedConfig);
   }
 
-  _fetch(url, config) {
+  _fetch(url, c) {
+    const config = merge(c, { method: c.method.toUpperCase() });
     const resolveFinally = (...args) => this._middleware.resolveFinally(...args);
 
     return this._middleware.resolveBefore(config)

--- a/test/trae/__snapshots__/delete.spec.js.snap
+++ b/test/trae/__snapshots__/delete.spec.js.snap
@@ -4,7 +4,7 @@ exports[`trae -> delete makes a DELETE request to baseURL + path 1`] = `
 Object {
   "config": Object {
     "headers": Object {},
-    "method": "delete",
+    "method": "DELETE",
     "url": "http://localhost:8080/api/foo",
   },
   "data": "Deleted!",

--- a/test/trae/__snapshots__/get.spec.js.snap
+++ b/test/trae/__snapshots__/get.spec.js.snap
@@ -4,7 +4,7 @@ exports[`trae -> get get -> params makes a GET request to baseURL + path using a
 Object {
   "config": Object {
     "headers": Object {},
-    "method": "get",
+    "method": "GET",
     "params": Object {
       "a": Object {
         "b": "c",
@@ -31,7 +31,7 @@ exports[`trae -> get get -> params makes a GET request to baseURL + path using p
 Object {
   "config": Object {
     "headers": Object {},
-    "method": "get",
+    "method": "GET",
     "params": Object {
       "foo": "bar",
       "key": 123,
@@ -58,7 +58,7 @@ exports[`trae -> get makes a GET request to baseURL + path 1`] = `
 Object {
   "config": Object {
     "headers": Object {},
-    "method": "get",
+    "method": "GET",
     "url": "http://localhost:8080/api/foo",
   },
   "data": Object {
@@ -81,7 +81,7 @@ Object {
   "config": Object {
     "bodyType": "raw",
     "headers": Object {},
-    "method": "get",
+    "method": "GET",
     "url": "http://localhost:8080/api/foo",
   },
   "data": Readable {

--- a/test/trae/__snapshots__/head.spec.js.snap
+++ b/test/trae/__snapshots__/head.spec.js.snap
@@ -4,7 +4,7 @@ exports[`trae -> head makes a HEAD request to baseURL + path 1`] = `
 Object {
   "config": Object {
     "headers": Object {},
-    "method": "head",
+    "method": "HEAD",
     "url": "http://localhost:8080/api/foo",
   },
   "data": "",

--- a/test/trae/__snapshots__/middleware.spec.js.snap
+++ b/test/trae/__snapshots__/middleware.spec.js.snap
@@ -4,7 +4,7 @@ exports[`trae - middleware after runs the fulfill after middlewares 1`] = `
 Object {
   "config": Object {
     "headers": Object {},
-    "method": "get",
+    "method": "GET",
     "url": "http://localhost:8080/api/foo",
   },
   "data": Object {
@@ -31,7 +31,7 @@ Object {
     "headers": Object {
       "Authorization": "12345Foo",
     },
-    "method": "get",
+    "method": "GET",
     "url": "http://localhost:8080/api/foo",
   },
   "data": Object {
@@ -53,7 +53,7 @@ exports[`trae - middleware finally runs the finally middlewares 1`] = `
 Object {
   "config": Object {
     "headers": Object {},
-    "method": "get",
+    "method": "GET",
     "mySpecialConfig": "unicorn",
     "url": "http://localhost:8080/api/foo",
   },

--- a/test/trae/__snapshots__/patch.spec.js.snap
+++ b/test/trae/__snapshots__/patch.spec.js.snap
@@ -13,7 +13,7 @@ Object {
     "headers": Object {
       "Content-Type": "application/json",
     },
-    "method": "patch",
+    "method": "PATCH",
     "patch": Object {
       "headers": Object {
         "Content-Type": "application/json",

--- a/test/trae/__snapshots__/post.spec.js.snap
+++ b/test/trae/__snapshots__/post.spec.js.snap
@@ -13,7 +13,7 @@ Object {
     "headers": Object {
       "Content-Type": "application/json",
     },
-    "method": "post",
+    "method": "POST",
     "post": Object {
       "headers": Object {
         "Content-Type": "application/json",
@@ -43,7 +43,7 @@ Object {
     "headers": Object {
       "Content-Type": "application/json",
     },
-    "method": "post",
+    "method": "POST",
     "params": Object {
       "a": Object {
         "b": "c",
@@ -78,7 +78,7 @@ Object {
     "headers": Object {
       "Content-Type": "application/json",
     },
-    "method": "post",
+    "method": "POST",
     "params": Object {
       "foo": "bar",
       "key": 123,

--- a/test/trae/__snapshots__/put.spec.js.snap
+++ b/test/trae/__snapshots__/put.spec.js.snap
@@ -13,7 +13,7 @@ Object {
     "headers": Object {
       "Content-Type": "application/json",
     },
-    "method": "put",
+    "method": "PUT",
     "put": Object {
       "headers": Object {
         "Content-Type": "application/json",

--- a/test/trae/__snapshots__/request.spec.js.snap
+++ b/test/trae/__snapshots__/request.spec.js.snap
@@ -7,7 +7,7 @@ Object {
       "baz": "foo",
     },
     "headers": Object {},
-    "method": "delete",
+    "method": "DELETE",
     "url": "http://localhost:8080/api/foo",
   },
   "data": Object {
@@ -29,7 +29,7 @@ exports[`trae -> request makes a GET request to baseURL + path using the request
 Object {
   "config": Object {
     "headers": Object {},
-    "method": "get",
+    "method": "GET",
     "params": Object {
       "bar": "test",
       "foo": "sar",
@@ -55,7 +55,7 @@ exports[`trae -> request makes a HEAD request to baseURL + path using the reques
 Object {
   "config": Object {
     "headers": Object {},
-    "method": "head",
+    "method": "HEAD",
     "url": "http://localhost:8080/api/foo",
   },
   "data": Object {
@@ -80,7 +80,7 @@ Object {
     "headers": Object {
       "Content-Type": "application/json",
     },
-    "method": "patch",
+    "method": "PATCH",
     "patch": Object {
       "headers": Object {
         "Content-Type": "application/json",
@@ -110,7 +110,7 @@ Object {
     "headers": Object {
       "Content-Type": "application/json",
     },
-    "method": "post",
+    "method": "POST",
     "post": Object {
       "headers": Object {
         "Content-Type": "application/json",
@@ -140,7 +140,7 @@ Object {
     "headers": Object {
       "Content-Type": "application/json",
     },
-    "method": "put",
+    "method": "PUT",
     "put": Object {
       "headers": Object {
         "Content-Type": "application/json",

--- a/test/trae/delete.spec.js
+++ b/test/trae/delete.spec.js
@@ -36,7 +36,7 @@ describe('trae -> delete', () => {
       expect(res).toMatchSnapshot();
       expect(fetchMock.called(url)).toBeTruthy();
       expect(fetchMock.lastUrl()).toBe(url);
-      expect(fetchMock.lastOptions().method).toBe('delete');
+      expect(fetchMock.lastOptions().method).toBe('DELETE');
     });
   });
 });

--- a/test/trae/get.spec.js
+++ b/test/trae/get.spec.js
@@ -53,7 +53,7 @@ describe('trae -> get', () => {
       expect(res).toMatchSnapshot();
       expect(fetchMock.called(url)).toBeTruthy();
       expect(fetchMock.lastUrl()).toBe(url);
-      expect(fetchMock.lastOptions().method).toBe('get');
+      expect(fetchMock.lastOptions().method).toBe('GET');
     });
   });
 
@@ -75,7 +75,7 @@ describe('trae -> get', () => {
       expect(res).toMatchSnapshot();
       expect(fetchMock.called(url)).toBeTruthy();
       expect(fetchMock.lastUrl()).toBe(url);
-      expect(fetchMock.lastOptions().method).toBe('get');
+      expect(fetchMock.lastOptions().method).toBe('GET');
     });
   });
 
@@ -108,7 +108,7 @@ describe('trae -> get', () => {
         expect(res).toMatchSnapshot();
         expect(fetchMock.called(url + qs)).toBeTruthy();
         expect(fetchMock.lastUrl()).toBe(url + qs);
-        expect(fetchMock.lastOptions().method).toBe('get');
+        expect(fetchMock.lastOptions().method).toBe('GET');
       });
     });
 
@@ -135,7 +135,7 @@ describe('trae -> get', () => {
         expect(res).toMatchSnapshot();
         expect(fetchMock.called(url + qs)).toBeTruthy();
         expect(fetchMock.lastUrl()).toBe(url + qs);
-        expect(fetchMock.lastOptions().method).toBe('get');
+        expect(fetchMock.lastOptions().method).toBe('GET');
       });
     });
   });

--- a/test/trae/head.spec.js
+++ b/test/trae/head.spec.js
@@ -32,7 +32,7 @@ describe('trae -> head', () => {
       expect(res).toMatchSnapshot();
       expect(fetchMock.called(url)).toBeTruthy();
       expect(fetchMock.lastUrl()).toBe(url);
-      expect(fetchMock.lastOptions().method).toBe('head');
+      expect(fetchMock.lastOptions().method).toBe('HEAD');
     });
   });
 });

--- a/test/trae/middleware.spec.js
+++ b/test/trae/middleware.spec.js
@@ -58,7 +58,7 @@ describe('trae - middleware', () => {
         expect(res).toMatchSnapshot();
         expect(fetchMock.called(url)).toBeTruthy();
         expect(fetchMock.lastUrl()).toBe(url);
-        expect(fetchMock.lastOptions().method).toBe('get');
+        expect(fetchMock.lastOptions().method).toBe('GET');
         expect(fetchMock.lastOptions().headers.Authorization).toBe('12345Foo');
       });
     });
@@ -93,7 +93,7 @@ describe('trae - middleware', () => {
         expect(res).toMatchSnapshot();
         expect(fetchMock.called(url)).toBeTruthy();
         expect(fetchMock.lastUrl()).toBe(url);
-        expect(fetchMock.lastOptions().method).toBe('get');
+        expect(fetchMock.lastOptions().method).toBe('GET');
       });
     });
 
@@ -126,7 +126,7 @@ describe('trae - middleware', () => {
         expect(err).toMatchSnapshot();
         expect(fetchMock.called(url)).toBeTruthy();
         expect(fetchMock.lastUrl()).toBe(url);
-        expect(fetchMock.lastOptions().method).toBe('get');
+        expect(fetchMock.lastOptions().method).toBe('GET');
       });
     });
   });
@@ -159,7 +159,7 @@ describe('trae - middleware', () => {
         expect(res).toMatchSnapshot();
         expect(fetchMock.called(url)).toBeTruthy();
         expect(fetchMock.lastUrl()).toBe(url);
-        expect(fetchMock.lastOptions().method).toBe('get');
+        expect(fetchMock.lastOptions().method).toBe('GET');
       });
     });
   });

--- a/test/trae/patch.spec.js
+++ b/test/trae/patch.spec.js
@@ -38,7 +38,7 @@ describe('trae -> patch', () => {
       expect(res).toMatchSnapshot();
       expect(fetchMock.called(url)).toBeTruthy();
       expect(fetchMock.lastUrl()).toBe(url);
-      expect(fetchMock.lastOptions().method).toBe('patch');
+      expect(fetchMock.lastOptions().method).toBe('PATCH');
     });
   });
 });

--- a/test/trae/post.spec.js
+++ b/test/trae/post.spec.js
@@ -38,7 +38,7 @@ describe('trae -> post', () => {
       expect(res).toMatchSnapshot();
       expect(fetchMock.called(url)).toBeTruthy();
       expect(fetchMock.lastUrl()).toBe(url);
-      expect(fetchMock.lastOptions().method).toBe('post');
+      expect(fetchMock.lastOptions().method).toBe('POST');
     });
   });
 
@@ -77,7 +77,7 @@ describe('trae -> post', () => {
         expect(res).toMatchSnapshot();
         expect(fetchMock.called(url + qs)).toBeTruthy();
         expect(fetchMock.lastUrl()).toBe(url + qs);
-        expect(fetchMock.lastOptions().method).toBe('post');
+        expect(fetchMock.lastOptions().method).toBe('POST');
       });
     });
 
@@ -108,7 +108,7 @@ describe('trae -> post', () => {
         expect(res).toMatchSnapshot();
         expect(fetchMock.called(url + qs)).toBeTruthy();
         expect(fetchMock.lastUrl()).toBe(url + qs);
-        expect(fetchMock.lastOptions().method).toBe('post');
+        expect(fetchMock.lastOptions().method).toBe('POST');
       });
     });
   });

--- a/test/trae/put.spec.js
+++ b/test/trae/put.spec.js
@@ -38,7 +38,7 @@ describe('trae -> put', () => {
       expect(res).toMatchSnapshot();
       expect(fetchMock.called(url)).toBeTruthy();
       expect(fetchMock.lastUrl()).toBe(url);
-      expect(fetchMock.lastOptions().method).toBe('put');
+      expect(fetchMock.lastOptions().method).toBe('PUT');
     });
   });
 });

--- a/test/trae/request.spec.js
+++ b/test/trae/request.spec.js
@@ -42,7 +42,7 @@ describe('trae -> request', () => {
       expect(res).toMatchSnapshot();
       expect(fetchMock.called(`${url}?foo=sar&bar=test`)).toBeTruthy();
       expect(fetchMock.lastUrl()).toBe(`${url}?foo=sar&bar=test`);
-      expect(fetchMock.lastOptions().method).toBe('get');
+      expect(fetchMock.lastOptions().method).toBe('GET');
     });
   });
 
@@ -72,7 +72,7 @@ describe('trae -> request', () => {
       expect(res).toMatchSnapshot();
       expect(fetchMock.called(url)).toBeTruthy();
       expect(fetchMock.lastUrl()).toBe(url);
-      expect(fetchMock.lastOptions().method).toBe('post');
+      expect(fetchMock.lastOptions().method).toBe('POST');
     });
   });
 
@@ -102,7 +102,7 @@ describe('trae -> request', () => {
       expect(res).toMatchSnapshot();
       expect(fetchMock.called(url)).toBeTruthy();
       expect(fetchMock.lastUrl()).toBe(url);
-      expect(fetchMock.lastOptions().method).toBe('put');
+      expect(fetchMock.lastOptions().method).toBe('PUT');
     });
   });
 
@@ -132,7 +132,7 @@ describe('trae -> request', () => {
       expect(res).toMatchSnapshot();
       expect(fetchMock.called(url)).toBeTruthy();
       expect(fetchMock.lastUrl()).toBe(url);
-      expect(fetchMock.lastOptions().method).toBe('patch');
+      expect(fetchMock.lastOptions().method).toBe('PATCH');
     });
   });
 
@@ -162,7 +162,7 @@ describe('trae -> request', () => {
       expect(res).toMatchSnapshot();
       expect(fetchMock.called(url)).toBeTruthy();
       expect(fetchMock.lastUrl()).toBe(url);
-      expect(fetchMock.lastOptions().method).toBe('delete');
+      expect(fetchMock.lastOptions().method).toBe('DELETE');
     });
   });
 
@@ -189,7 +189,7 @@ describe('trae -> request', () => {
       expect(res).toMatchSnapshot();
       expect(fetchMock.called(url)).toBeTruthy();
       expect(fetchMock.lastUrl()).toBe(url);
-      expect(fetchMock.lastOptions().method).toBe('head');
+      expect(fetchMock.lastOptions().method).toBe('HEAD');
     });
   });
 });


### PR DESCRIPTION
As defined in the [HTTP Semantics and Content Standard](
https://tools.ietf.org/html/rfc7231#section-4.1) HTTP request methods should be uppercase.