### PR TITLE
Create coverage directory before building

### DIFF
--- a/build/rollup.js
+++ b/build/rollup.js
@@ -11,16 +11,17 @@ const visualizer         = require('rollup-plugin-visualizer');
 const builtins           = require('rollup-plugin-node-builtins');
 const globals            = require('rollup-plugin-node-globals');
 const json               = require('rollup-plugin-json');
+const mkdirp             = require('mkdirp');
 
 const skipCommentsCustom = require('./uglify-skip-comments');
 const generateBanner     = require('./generate-banner');
 const generateBundleName = require('./generate-bundle-name');
 const pkg                = require('../package.json');
 
-
 const env    = process.env.NODE_ENV || 'development';
 const isProd = env === 'production';
 
+mkdirp('./coverage');
 
 let promise = Promise.resolve();
 

--- a/build/rollup.js
+++ b/build/rollup.js
@@ -21,7 +21,7 @@ const pkg                = require('../package.json');
 const env    = process.env.NODE_ENV || 'development';
 const isProd = env === 'production';
 
-mkdirp('./coverage');
+mkdirp('./dist');
 
 let promise = Promise.resolve();
 
@@ -60,7 +60,7 @@ let promise = Promise.resolve();
         'process.env.NODE_ENV': JSON.stringify(env),
         NODE_ENV              : JSON.stringify(env)
       }),
-      visualizer({ filename: `./coverage/${format}-bundle-statistics.html` }),
+      visualizer({ filename: `./dist/${format}-bundle-statistics.html` }),
       conditional(isProd && format === 'umd', [uglify({ output: { comments: skipCommentsCustom } })]),
       filesize()
     ]

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "http-server": "^0.10.0",
     "in-publish": "^2.0.0",
     "jest": "^20.0.1",
+    "mkdirp": "^0.5.1",
     "np": "^2.14.1",
     "pre-commit": "^1.2.2",
     "rollup": "^0.41.4",


### PR DESCRIPTION
Running `npm run build` after cloning the repo throws an error because the `coverage` directory does not exist. This PR creates the directory before running rollup.