### PR TITLE
Add prettier & update eslint config

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,5 @@
 node_modules
 coverage
 dist/*
-docs/js/*.min.js
+docs/js/*.js
 examples

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,29 +1,14 @@
 {
-  "extends": "airbnb",
+  "extends": [
+    "airbnb",
+    "prettier"
+  ],
   "rules": {
-    "no-multi-spaces": 0,
     "no-underscore-dangle": [0],
-    "consistent-return": 0,
     "no-unused-expressions": [2, { "allowShortCircuit": true }],
     "no-param-reassign": 0,
-    "func-names": 0,
-    "space-before-function-paren": [2, "never"],
-    "comma-dangle": [2, "never"],
-    "no-shadow": 0,
-    "guard-for-in": 0,
-    "no-restricted-syntax": [2, "WithStatement"],
-    "newline-per-chained-call": [2, { "ignoreChainWithDepth": 5 }],
-    "space-in-parens": 0,
-    "key-spacing": 0,
-    "no-unused-vars": [2, { "vars": "all", "args": "none" }],
-    "max-len": 1,
-    "padded-blocks": 0,
     "no-console": 0,
-    "no-continue": 0,
-    "import/extensions": 0,
     "import/no-extraneous-dependencies": 0,
-    "import/newline-after-import": 0,
-    "no-mixed-operators": 0,
     "no-useless-escape": 0
   },
   "globals": {

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+node_modules
+coverage
+dist
+stats
+package-lock.json
+package.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "printWidth": 80,
+  "semi": false,
+  "trailingComma": "all",
+  "singleQuote": true,
+  "arrowParens": "always"
+}

--- a/README.md
+++ b/README.md
@@ -14,23 +14,23 @@ Minimalistic HTTP client for the browser and Node. Based on [Fetch](https://deve
 
 ## Content
 
-1. [Install](#install)
-1. [Basic Usage](#basic-usage)
-1. [Trae API](#trea-api)
-  1. [Request methods](#request-methods)
-  1. [Config](#config)
-  1. [Defaults](#defaults)
-  1. [Middlewares](#middlewares)
-  1. [Instances](#instances)
-1. [Response](#response)
-  1. [Data](#data)
-  1. [Headers](#headers)
-1. [Rejection](#rejection)
-1. [Resources](#resources)
-1. [License](#license)
-1. [Contributing](#contributing)
-1. [Contributors](#contributors)
-1. [TODO](#todo)
+1.  [Install](#install)
+1.  [Basic Usage](#basic-usage)
+1.  [Trae API](#trea-api)
+    1.  [Request methods](#request-methods)
+    1.  [Config](#config)
+    1.  [Defaults](#defaults)
+    1.  [Middlewares](#middlewares)
+    1.  [Instances](#instances)
+1.  [Response](#response)
+    1.  [Data](#data)
+    1.  [Headers](#headers)
+1.  [Rejection](#rejection)
+1.  [Resources](#resources)
+1.  [License](#license)
+1.  [Contributing](#contributing)
+1.  [Contributors](#contributors)
+1.  [TODO](#todo)
 
 ## Install
 
@@ -47,13 +47,14 @@ $ yarn add trae
 A `GET` request to `https://www.google.com.ar/search?q=foo`:
 
 ```js
-trae.get('https://www.google.com.ar/search', { params: { q: 'foo' } })
+trae
+  .get('https://www.google.com.ar/search', { params: { q: 'foo' } })
   .then((response) => {
-    console.log(response);
+    console.log(response)
   })
   .catch((err) => {
-    console.error(err);
-  });
+    console.error(err)
+  })
 ```
 
 A `POST` request to `https://www.foo.com/api/posts`:
@@ -110,7 +111,7 @@ The configuration object can be used in all request methods, the following attri
   },
 
   // Represents the body of the response, allowing you to declare what its content type is and how it should be handled.
-  // Available readers are `arrayBuffer`, `blob`, `formData`, `json`, `text` and `raw`. The last one returns the response body without being     
+  // Available readers are `arrayBuffer`, `blob`, `formData`, `json`, `text` and `raw`. The last one returns the response body without being
   // parsed. `raw` is used for streaming the response body among other things.
   // @link: https://developer.mozilla.org/en-US/docs/Web/API/Body
   bodyType: 'json',
@@ -138,6 +139,7 @@ The configuration object can be used in all request methods, the following attri
   cache: 'only-if-cached'
 }
 ```
+
 More information about Request properties can be found on this [`MDN article`](https://developer.mozilla.org/en-US/docs/Web/API/Request).
 
 ### Defaults
@@ -148,15 +150,15 @@ Sets the default configuration to use on every requests. This is merged with the
 
 ```js
 trae.defaults({
-  mode       : 'no-cors',
-  credentials: 'same-origin'
-});
+  mode: 'no-cors',
+  credentials: 'same-origin',
+})
 ```
 
 When called with no params acts as a getter, returning the defined defaults.
 
 ```js
-const config = trae.defaults();
+const config = trae.defaults()
 ```
 
 It is possible to set default configuration for specific methods passing an
@@ -166,19 +168,19 @@ object with the method as key:
 trae.defaults({
   post: {
     headers: {
-      'Content-Type': 'application/x-www-form-urlencoded'
-    }
-  }
-});
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+  },
+})
 ```
 
 #### Request configuration precedence
 
 The configuration for a request will be merged following this precedence rules, each level overrides the followings:
 
-  1. Request params config.
-  1. Method config set with `trae.defaults({ [method]: { ... } })`.
-  1. Trae config set with `trae.defaults({ ... })`.
+1.  Request params config.
+1.  Method config set with `trae.defaults({ [method]: { ... } })`.
+1.  Trae config set with `trae.defaults({ ... })`.
 
 #### `trae.baseUrl([url])`
 
@@ -203,11 +205,11 @@ Runs before the request is made and it has access to the configuration object, i
 
 ```js
 const beforeMiddleware = (config) => {
-  config.headers['X-ACCESSS-TOKEN'] = getUserToken();
-  return config;
+  config.headers['X-ACCESSS-TOKEN'] = getUserToken()
+  return config
 }
 
-trae.before(beforeMiddleware);
+trae.before(beforeMiddleware)
 ```
 
 #### `trae.after(fullfill[, reject])`
@@ -216,18 +218,18 @@ Runs after the request is made, it chains the provided `fullfill` and `reject` m
 
 ```js
 const fullfillMiddleware = (res) => {
-  console.log(res);
+  console.log(res)
   res.data.foo = 'bar'
-  return res;
-};
+  return res
+}
 
 const rejectMiddleware = (err) => {
-  console.error(err);
-  err.foo = 'bar';
-  return Promise.reject(err);
-};
+  console.error(err)
+  err.foo = 'bar'
+  return Promise.reject(err)
+}
 
-trae.after(fullfillMiddleware, rejectMiddleware);
+trae.after(fullfillMiddleware, rejectMiddleware)
 ```
 
 Using the above `after` middleware is the same as doing:
@@ -239,15 +241,15 @@ trae.get('/api/posts')
 
 #### `trae.finally([middleware])`
 
-Runs at the end regardless of the request result, it has access to the configuration object and the url that was used to made the request. Is not promise based. Functions provided to this method are run synchronously. 
+Runs at the end regardless of the request result, it has access to the configuration object and the url that was used to made the request. Is not promise based. Functions provided to this method are run synchronously.
 
 ```js
 const finallyMiddleware = (config, url) => {
-  console.log('The End');
-  makeTheSpinnerStop();
-};
+  console.log('The End')
+  makeTheSpinnerStop()
+}
 
-trae.finally(finallyMiddleware);
+trae.finally(finallyMiddleware)
 ```
 
 [⬆ back to top](#content)
@@ -324,10 +326,10 @@ On rejection an `Error` is passed to the rejection middleware with the same prop
 
 ## Resources
 
-- Motivation: if you want to know more about the motivations behind this library check out [this article](https://hackernoon.com/trae-another-http-library-70000860a5f4).
-- Middlewares
-  - [`trae-events`](https://github.com/Huemul/trae-events).
-  - [`trae-logger`](https://github.com/Huemul/trae-logger).
+* Motivation: if you want to know more about the motivations behind this library check out [this article](https://hackernoon.com/trae-another-http-library-70000860a5f4).
+* Middlewares
+  * [`trae-events`](https://github.com/Huemul/trae-events).
+  * [`trae-logger`](https://github.com/Huemul/trae-logger).
 
 ## License
 
@@ -346,19 +348,22 @@ This project follows the [all-contributors](https://github.com/kentcdodds/all-co
 Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds/all-contributors#emoji-key)):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+
 | [<img src="https://avatars.githubusercontent.com/u/6719053?v=3" width="64px;"/><br /><sub>Nicolas Del Valle</sub>](http://nico.delvalle.xyz)<br />[💻](https://github.com/Huemul/trae/commits?author=ndelvalle) [📖](https://github.com/Huemul/trae/commits?author=ndelvalle) [⚠️](https://github.com/Huemul/trae/commits?author=ndelvalle) 💡 👀 | [<img src="https://avatars.githubusercontent.com/u/8309423?v=3" width="64px;"/><br /><sub>Christian Gill</sub>](https://gillchristian.xyz)<br />[💻](https://github.com/Huemul/trae/commits?author=gillchristian) [📖](https://github.com/Huemul/trae/commits?author=gillchristian) [⚠️](https://github.com/Huemul/trae/commits?author=gillchristian) 💡 👀 | [<img src="https://avatars.githubusercontent.com/u/3258966?v=3" width="64px;"/><br /><sub>Ignacio Anaya</sub>](http://keepe.rs)<br />[💻](https://github.com/Huemul/trae/commits?author=ianaya89) 👀 🎨 [🐛](https://github.com/Huemul/trae/issues?q=author%3Aianaya89) 💁 | [<img src="https://avatars.githubusercontent.com/u/1145624?v=3" width="64px;"/><br /><sub>Fred Guest</sub>](https://twitter.com/fredguest)<br />💁 [🐛](https://github.com/Huemul/trae/issues?q=author%3Afredguest) | [<img src="https://avatars.githubusercontent.com/u/11802102?v=3" width="64px;"/><br /><sub>Joni</sub>](http://joni.website)<br />🎨 | [<img src="https://avatars.githubusercontent.com/u/4614574?v=3" width="64px;"/><br /><sub>Gerardo Nardelli</sub>](https://gnardelli.com)<br />[📖](https://github.com/Huemul/trae/commits?author=patitonar) |
-| :---: | :---: | :---: | :---: | :---: | :---: |
+| :-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------------------------------------------: | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------: |
+
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 [⬆ back to top](#content)
 
 ## TODO
 
-- [ ] Provide a build with no polyfill.
-- [ ] CHANGELOG. [#48](https://github.com/Huemul/trae/issues/48)
-- [ ] Add logging and warnings to the dev build. [#49](https://github.com/Huemul/trae/issues/49#issuecomment-272533323)
-- [ ] Improve examples and add more. [`trae-exampels` repo](https://github.com/Huemul/trae-examples/).
-- [ ] Add a way to remove middlewares.
-- [ ] Add browser based tests.
+* [ ] Provide a build with no polyfill.
+* [ ] CHANGELOG. [#48](https://github.com/Huemul/trae/issues/48)
+* [ ] Add logging and warnings to the dev build. [#49](https://github.com/Huemul/trae/issues/49#issuecomment-272533323)
+* [ ] Improve examples and add more. [`trae-exampels` repo](https://github.com/Huemul/trae-examples/).
+* [ ] Add a way to remove middlewares.
+* [ ] Add browser based tests.
 
 [⬆ back to top](#content)

--- a/build/generate-banner.js
+++ b/build/generate-banner.js
@@ -4,7 +4,7 @@ module.exports = (version, author, contributors) => {
   *
   * @version: ${version}
   * @authors: ${author} | ${contributors[0]}
-  */`;
+  */`
 
-  return banner;
-};
+  return banner
+}

--- a/build/generate-bundle-name.js
+++ b/build/generate-bundle-name.js
@@ -1,6 +1,6 @@
 module.exports = (format, isProd) => {
   if (format === 'cjs') {
-    return 'trae';
+    return 'trae'
   }
-  return isProd ? 'trae.umd.min' : 'trae.umd';
-};
+  return isProd ? 'trae.umd.min' : 'trae.umd'
+}

--- a/build/rollup.js
+++ b/build/rollup.js
@@ -1,87 +1,92 @@
-const rollup             = require('rollup');
-const uglify             = require('rollup-plugin-uglify');
-const babel              = require('rollup-plugin-babel');
-const replace            = require('rollup-plugin-replace');
-const eslint             = require('rollup-plugin-eslint');
-const conditional        = require('rollup-plugin-conditional');
-const filesize           = require('rollup-plugin-filesize');
-const resolve            = require('rollup-plugin-node-resolve');
-const commonjs           = require('rollup-plugin-commonjs');
-const visualizer         = require('rollup-plugin-visualizer');
-const builtins           = require('rollup-plugin-node-builtins');
-const globals            = require('rollup-plugin-node-globals');
-const json               = require('rollup-plugin-json');
-const mkdirp             = require('mkdirp');
+const rollup = require('rollup')
+const uglify = require('rollup-plugin-uglify')
+const babel = require('rollup-plugin-babel')
+const replace = require('rollup-plugin-replace')
+const eslint = require('rollup-plugin-eslint')
+const conditional = require('rollup-plugin-conditional')
+const filesize = require('rollup-plugin-filesize')
+const resolve = require('rollup-plugin-node-resolve')
+const commonjs = require('rollup-plugin-commonjs')
+const visualizer = require('rollup-plugin-visualizer')
+const builtins = require('rollup-plugin-node-builtins')
+const globals = require('rollup-plugin-node-globals')
+const json = require('rollup-plugin-json')
+const mkdirp = require('mkdirp')
 
-const skipCommentsCustom = require('./uglify-skip-comments');
-const generateBanner     = require('./generate-banner');
-const generateBundleName = require('./generate-bundle-name');
-const pkg                = require('../package.json');
+const skipCommentsCustom = require('./uglify-skip-comments')
+const generateBanner = require('./generate-banner')
+const generateBundleName = require('./generate-bundle-name')
+const pkg = require('../package.json')
 
-const env    = process.env.NODE_ENV || 'development';
-const isProd = env === 'production';
+const env = process.env.NODE_ENV || 'development'
+const isProd = env === 'production'
 
-mkdirp('./dist');
-mkdirp('./stats');
+mkdirp('./dist')
+mkdirp('./stats')
 
-let bundles = Promise.resolve();
+let bundles = Promise.resolve()
 
-const inputOptions = format => ({
+const inputOptions = (format) => ({
   input: 'lib/index.js',
   plugins: [
     json({
-      include    : 'package.json',
-      preferConst: true
+      include: 'package.json',
+      preferConst: true,
     }),
     eslint({
-      exclude: 'package.json'
+      exclude: 'package.json',
     }),
     conditional(format === 'cjs', [globals(), builtins()]),
     resolve({
-      jsnext        : format === 'umd',
-      main          : true,
-      browser       : format === 'umd',
-      preferBuiltins: true
+      jsnext: format === 'umd',
+      main: true,
+      browser: format === 'umd',
+      preferBuiltins: true,
     }),
     commonjs(),
     babel({
       babelrc: false, // jest makes use of .babelrc
       presets: [['@babel/preset-env', { modules: false }]],
-      exclude: ['node_modules/**', 'package.json']
+      exclude: ['node_modules/**', 'package.json'],
     }),
     replace({
       exclude: ['node_modules/**', 'package.json'],
       values: {
         'process.env.NODE_ENV': JSON.stringify(env),
-        NODE_ENV              : JSON.stringify(env)
-      }
+        NODE_ENV: JSON.stringify(env),
+      },
     }),
     visualizer({ filename: `./stats/${format}-bundle-statistics.html` }),
-    conditional(isProd && format === 'umd', [uglify({ output: { comments: skipCommentsCustom } })]),
-    filesize()
-  ]
-});
+    conditional(isProd && format === 'umd', [
+      uglify({ output: { comments: skipCommentsCustom } }),
+    ]),
+    filesize(),
+  ],
+})
 
-const outputOptions = format => ({
+const outputOptions = (format) => ({
   format,
-  dir : 'dist',
+  dir: 'dist',
   file: `dist/${generateBundleName(format, isProd)}.js`,
   // The variable name, representing the umd bundle, by which other scripts on the same
   // page can access it
-  name         : format === 'umd' ? pkg.name : undefined,
+  name: format === 'umd' ? pkg.name : undefined,
   sourcemapFile: 'dist',
-  banner       : generateBanner(pkg.version, pkg.author, pkg.contributors)
-});
+  banner: generateBanner(pkg.version, pkg.author, pkg.contributors),
+})
 
-const build = opts => rollup.rollup(opts.input).then(bundle => bundle.write(opts.output));
+const build = (opts) =>
+  rollup.rollup(opts.input).then((bundle) => bundle.write(opts.output))
 
 // cjs – CommonJS, suitable for Node and Browserify/Webpack
 // umd – Universal Module Definition, works as amd, cjs and iife all in one
-['cjs', 'umd'].forEach((format) => {
-  bundles = bundles.then(() => build({
-    input: inputOptions(format),
-    output: outputOptions(format)
-  }));
-});
+;['cjs', 'umd'].forEach((format) => {
+  bundles = bundles.then(() =>
+    build({
+      input: inputOptions(format),
+      output: outputOptions(format),
+    }),
+  )
+})
 
-bundles.catch(err => console.error(err.stack));
+bundles.catch((err) => console.error(err.stack))

--- a/build/uglify-skip-comments.js
+++ b/build/uglify-skip-comments.js
@@ -1,6 +1,7 @@
+// eslint-disable-next-line consistent-return
 module.exports = (node, { type, value }) => {
   if (type === 'comment') {
     // multiline comment
-    return /Trae/i.test(value);
+    return /Trae/i.test(value)
   }
-};
+}

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -1,38 +1,39 @@
 /* globals document trae */
 
-((t) => {
+;((t) => {
+  const result = document.getElementById('result')
+  const loading = document.getElementById('loading-text')
+  const url = 'https://jsonplaceholder.typicode.com/posts/1'
 
-  const result = document.getElementById('result');
-  const loading = document.getElementById('loading-text');
-  const url = 'https://jsonplaceholder.typicode.com/posts/1';
-
-  let i = 0;
+  let i = 0
   const interval = setInterval(() => {
     // eslint-disable-next-line prefer-template
-    loading.innerHTML = '// Loading ' + Array(i).fill('.').join('');
+    loading.innerHTML =
+      '// Loading ' +
+      Array(i)
+        .fill('.')
+        .join('')
     // eslint-disable-next-line no-plusplus
-    i = i++ < 3 ? i : 0;
-  }, 200);
+    i = i++ < 3 ? i : 0
+  }, 200)
 
   function success(res) {
     // eslint-disable-next-line prefer-template
-    res.data.title = res.data.title.slice(0, 8);
+    res.data.title = res.data.title.slice(0, 8)
     // eslint-disable-next-line prefer-template
-    res.data.body = res.data.body.slice(0, 20) + '...';
-    return Promise.resolve(res);
+    res.data.body = res.data.body.slice(0, 20) + '...'
+    return Promise.resolve(res)
   }
 
-  trae.after(success);
+  trae.after(success)
 
-  trae.get(url)
-  .then((res) => {
-    clearInterval(interval);
-    console.log(res);
-    result.removeChild(loading);
+  trae.get(url).then((res) => {
+    clearInterval(interval)
+    console.log(res)
+    result.removeChild(loading)
 
-    let html = '\n// request final reponse\n';
-    html += JSON.stringify(res, null, '\t');
-    result.innerHTML += html;
-  });
-
-})(trae);
+    let html = '\n// request final reponse\n'
+    html += JSON.stringify(res, null, '\t')
+    result.innerHTML += html
+  })
+})(trae)

--- a/docs/js/prism.min.js
+++ b/docs/js/prism.min.js
@@ -1,10 +1,704 @@
 /* http://prismjs.com/download.html?themes=prism-okaidia&languages=markup+css+clike+javascript&plugins=line-numbers+toolbar+show-language+copy-to-clipboard */
-var _self="undefined"!=typeof window?window:"undefined"!=typeof WorkerGlobalScope&&self instanceof WorkerGlobalScope?self:{},Prism=function(){var e=/\blang(?:uage)?-(\w+)\b/i,t=0,n=_self.Prism={util:{encode:function(e){return e instanceof a?new a(e.type,n.util.encode(e.content),e.alias):"Array"===n.util.type(e)?e.map(n.util.encode):e.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/\u00a0/g," ")},type:function(e){return Object.prototype.toString.call(e).match(/\[object (\w+)\]/)[1]},objId:function(e){return e.__id||Object.defineProperty(e,"__id",{value:++t}),e.__id},clone:function(e){var t=n.util.type(e);switch(t){case"Object":var a={};for(var r in e)e.hasOwnProperty(r)&&(a[r]=n.util.clone(e[r]));return a;case"Array":return e.map&&e.map(function(e){return n.util.clone(e)})}return e}},languages:{extend:function(e,t){var a=n.util.clone(n.languages[e]);for(var r in t)a[r]=t[r];return a},insertBefore:function(e,t,a,r){r=r||n.languages;var i=r[e];if(2==arguments.length){a=arguments[1];for(var l in a)a.hasOwnProperty(l)&&(i[l]=a[l]);return i}var o={};for(var s in i)if(i.hasOwnProperty(s)){if(s==t)for(var l in a)a.hasOwnProperty(l)&&(o[l]=a[l]);o[s]=i[s]}return n.languages.DFS(n.languages,function(t,n){n===r[e]&&t!=e&&(this[t]=o)}),r[e]=o},DFS:function(e,t,a,r){r=r||{};for(var i in e)e.hasOwnProperty(i)&&(t.call(e,i,e[i],a||i),"Object"!==n.util.type(e[i])||r[n.util.objId(e[i])]?"Array"!==n.util.type(e[i])||r[n.util.objId(e[i])]||(r[n.util.objId(e[i])]=!0,n.languages.DFS(e[i],t,i,r)):(r[n.util.objId(e[i])]=!0,n.languages.DFS(e[i],t,null,r)))}},plugins:{},highlightAll:function(e,t){var a={callback:t,selector:'code[class*="language-"], [class*="language-"] code, code[class*="lang-"], [class*="lang-"] code'};n.hooks.run("before-highlightall",a);for(var r,i=a.elements||document.querySelectorAll(a.selector),l=0;r=i[l++];)n.highlightElement(r,e===!0,a.callback)},highlightElement:function(t,a,r){for(var i,l,o=t;o&&!e.test(o.className);)o=o.parentNode;o&&(i=(o.className.match(e)||[,""])[1].toLowerCase(),l=n.languages[i]),t.className=t.className.replace(e,"").replace(/\s+/g," ")+" language-"+i,o=t.parentNode,/pre/i.test(o.nodeName)&&(o.className=o.className.replace(e,"").replace(/\s+/g," ")+" language-"+i);var s=t.textContent,u={element:t,language:i,grammar:l,code:s};if(n.hooks.run("before-sanity-check",u),!u.code||!u.grammar)return n.hooks.run("complete",u),void 0;if(n.hooks.run("before-highlight",u),a&&_self.Worker){var g=new Worker(n.filename);g.onmessage=function(e){u.highlightedCode=e.data,n.hooks.run("before-insert",u),u.element.innerHTML=u.highlightedCode,r&&r.call(u.element),n.hooks.run("after-highlight",u),n.hooks.run("complete",u)},g.postMessage(JSON.stringify({language:u.language,code:u.code,immediateClose:!0}))}else u.highlightedCode=n.highlight(u.code,u.grammar,u.language),n.hooks.run("before-insert",u),u.element.innerHTML=u.highlightedCode,r&&r.call(t),n.hooks.run("after-highlight",u),n.hooks.run("complete",u)},highlight:function(e,t,r){var i=n.tokenize(e,t);return a.stringify(n.util.encode(i),r)},tokenize:function(e,t){var a=n.Token,r=[e],i=t.rest;if(i){for(var l in i)t[l]=i[l];delete t.rest}e:for(var l in t)if(t.hasOwnProperty(l)&&t[l]){var o=t[l];o="Array"===n.util.type(o)?o:[o];for(var s=0;s<o.length;++s){var u=o[s],g=u.inside,c=!!u.lookbehind,h=!!u.greedy,f=0,d=u.alias;if(h&&!u.pattern.global){var p=u.pattern.toString().match(/[imuy]*$/)[0];u.pattern=RegExp(u.pattern.source,p+"g")}u=u.pattern||u;for(var m=0,y=0;m<r.length;y+=r[m].length,++m){var v=r[m];if(r.length>e.length)break e;if(!(v instanceof a)){u.lastIndex=0;var b=u.exec(v),k=1;if(!b&&h&&m!=r.length-1){if(u.lastIndex=y,b=u.exec(e),!b)break;for(var w=b.index+(c?b[1].length:0),_=b.index+b[0].length,A=m,P=y,j=r.length;j>A&&_>P;++A)P+=r[A].length,w>=P&&(++m,y=P);if(r[m]instanceof a||r[A-1].greedy)continue;k=A-m,v=e.slice(y,P),b.index-=y}if(b){c&&(f=b[1].length);var w=b.index+f,b=b[0].slice(f),_=w+b.length,O=v.slice(0,w),x=v.slice(_),S=[m,k];O&&S.push(O);var N=new a(l,g?n.tokenize(b,g):b,d,b,h);S.push(N),x&&S.push(x),Array.prototype.splice.apply(r,S)}}}}}return r},hooks:{all:{},add:function(e,t){var a=n.hooks.all;a[e]=a[e]||[],a[e].push(t)},run:function(e,t){var a=n.hooks.all[e];if(a&&a.length)for(var r,i=0;r=a[i++];)r(t)}}},a=n.Token=function(e,t,n,a,r){this.type=e,this.content=t,this.alias=n,this.length=0|(a||"").length,this.greedy=!!r};if(a.stringify=function(e,t,r){if("string"==typeof e)return e;if("Array"===n.util.type(e))return e.map(function(n){return a.stringify(n,t,e)}).join("");var i={type:e.type,content:a.stringify(e.content,t,r),tag:"span",classes:["token",e.type],attributes:{},language:t,parent:r};if("comment"==i.type&&(i.attributes.spellcheck="true"),e.alias){var l="Array"===n.util.type(e.alias)?e.alias:[e.alias];Array.prototype.push.apply(i.classes,l)}n.hooks.run("wrap",i);var o=Object.keys(i.attributes).map(function(e){return e+'="'+(i.attributes[e]||"").replace(/"/g,"&quot;")+'"'}).join(" ");return"<"+i.tag+' class="'+i.classes.join(" ")+'"'+(o?" "+o:"")+">"+i.content+"</"+i.tag+">"},!_self.document)return _self.addEventListener?(_self.addEventListener("message",function(e){var t=JSON.parse(e.data),a=t.language,r=t.code,i=t.immediateClose;_self.postMessage(n.highlight(r,n.languages[a],a)),i&&_self.close()},!1),_self.Prism):_self.Prism;var r=document.currentScript||[].slice.call(document.getElementsByTagName("script")).pop();return r&&(n.filename=r.src,document.addEventListener&&!r.hasAttribute("data-manual")&&("loading"!==document.readyState?window.requestAnimationFrame?window.requestAnimationFrame(n.highlightAll):window.setTimeout(n.highlightAll,16):document.addEventListener("DOMContentLoaded",n.highlightAll))),_self.Prism}();"undefined"!=typeof module&&module.exports&&(module.exports=Prism),"undefined"!=typeof global&&(global.Prism=Prism);
-Prism.languages.markup={comment:/<!--[\w\W]*?-->/,prolog:/<\?[\w\W]+?\?>/,doctype:/<!DOCTYPE[\w\W]+?>/i,cdata:/<!\[CDATA\[[\w\W]*?]]>/i,tag:{pattern:/<\/?(?!\d)[^\s>\/=$<]+(?:\s+[^\s>\/=]+(?:=(?:("|')(?:\\\1|\\?(?!\1)[\w\W])*\1|[^\s'">=]+))?)*\s*\/?>/i,inside:{tag:{pattern:/^<\/?[^\s>\/]+/i,inside:{punctuation:/^<\/?/,namespace:/^[^\s>\/:]+:/}},"attr-value":{pattern:/=(?:('|")[\w\W]*?(\1)|[^\s>]+)/i,inside:{punctuation:/[=>"']/}},punctuation:/\/?>/,"attr-name":{pattern:/[^\s>\/]+/,inside:{namespace:/^[^\s>\/:]+:/}}}},entity:/&#?[\da-z]{1,8};/i},Prism.hooks.add("wrap",function(a){"entity"===a.type&&(a.attributes.title=a.content.replace(/&amp;/,"&"))}),Prism.languages.xml=Prism.languages.markup,Prism.languages.html=Prism.languages.markup,Prism.languages.mathml=Prism.languages.markup,Prism.languages.svg=Prism.languages.markup;
-Prism.languages.css={comment:/\/\*[\w\W]*?\*\//,atrule:{pattern:/@[\w-]+?.*?(;|(?=\s*\{))/i,inside:{rule:/@[\w-]+/}},url:/url\((?:(["'])(\\(?:\r\n|[\w\W])|(?!\1)[^\\\r\n])*\1|.*?)\)/i,selector:/[^\{\}\s][^\{\};]*?(?=\s*\{)/,string:{pattern:/("|')(\\(?:\r\n|[\w\W])|(?!\1)[^\\\r\n])*\1/,greedy:!0},property:/(\b|\B)[\w-]+(?=\s*:)/i,important:/\B!important\b/i,"function":/[-a-z0-9]+(?=\()/i,punctuation:/[(){};:]/},Prism.languages.css.atrule.inside.rest=Prism.util.clone(Prism.languages.css),Prism.languages.markup&&(Prism.languages.insertBefore("markup","tag",{style:{pattern:/(<style[\w\W]*?>)[\w\W]*?(?=<\/style>)/i,lookbehind:!0,inside:Prism.languages.css,alias:"language-css"}}),Prism.languages.insertBefore("inside","attr-value",{"style-attr":{pattern:/\s*style=("|').*?\1/i,inside:{"attr-name":{pattern:/^\s*style/i,inside:Prism.languages.markup.tag.inside},punctuation:/^\s*=\s*['"]|['"]\s*$/,"attr-value":{pattern:/.+/i,inside:Prism.languages.css}},alias:"language-css"}},Prism.languages.markup.tag));
-Prism.languages.clike={comment:[{pattern:/(^|[^\\])\/\*[\w\W]*?\*\//,lookbehind:!0},{pattern:/(^|[^\\:])\/\/.*/,lookbehind:!0}],string:{pattern:/(["'])(\\(?:\r\n|[\s\S])|(?!\1)[^\\\r\n])*\1/,greedy:!0},"class-name":{pattern:/((?:\b(?:class|interface|extends|implements|trait|instanceof|new)\s+)|(?:catch\s+\())[a-z0-9_\.\\]+/i,lookbehind:!0,inside:{punctuation:/(\.|\\)/}},keyword:/\b(if|else|while|do|for|return|in|instanceof|function|new|try|throw|catch|finally|null|break|continue)\b/,"boolean":/\b(true|false)\b/,"function":/[a-z0-9_]+(?=\()/i,number:/\b-?(?:0x[\da-f]+|\d*\.?\d+(?:e[+-]?\d+)?)\b/i,operator:/--?|\+\+?|!=?=?|<=?|>=?|==?=?|&&?|\|\|?|\?|\*|\/|~|\^|%/,punctuation:/[{}[\];(),.:]/};
-Prism.languages.javascript=Prism.languages.extend("clike",{keyword:/\b(as|async|await|break|case|catch|class|const|continue|debugger|default|delete|do|else|enum|export|extends|finally|for|from|function|get|if|implements|import|in|instanceof|interface|let|new|null|of|package|private|protected|public|return|set|static|super|switch|this|throw|try|typeof|var|void|while|with|yield)\b/,number:/\b-?(0x[\dA-Fa-f]+|0b[01]+|0o[0-7]+|\d*\.?\d+([Ee][+-]?\d+)?|NaN|Infinity)\b/,"function":/[_$a-zA-Z\xA0-\uFFFF][_$a-zA-Z0-9\xA0-\uFFFF]*(?=\()/i,operator:/--?|\+\+?|!=?=?|<=?|>=?|==?=?|&&?|\|\|?|\?|\*\*?|\/|~|\^|%|\.{3}/}),Prism.languages.insertBefore("javascript","keyword",{regex:{pattern:/(^|[^\/])\/(?!\/)(\[.+?]|\\.|[^\/\\\r\n])+\/[gimyu]{0,5}(?=\s*($|[\r\n,.;})]))/,lookbehind:!0,greedy:!0}}),Prism.languages.insertBefore("javascript","string",{"template-string":{pattern:/`(?:\\\\|\\?[^\\])*?`/,greedy:!0,inside:{interpolation:{pattern:/\$\{[^}]+\}/,inside:{"interpolation-punctuation":{pattern:/^\$\{|\}$/,alias:"punctuation"},rest:Prism.languages.javascript}},string:/[\s\S]+/}}}),Prism.languages.markup&&Prism.languages.insertBefore("markup","tag",{script:{pattern:/(<script[\w\W]*?>)[\w\W]*?(?=<\/script>)/i,lookbehind:!0,inside:Prism.languages.javascript,alias:"language-javascript"}}),Prism.languages.js=Prism.languages.javascript;
-!function(){"undefined"!=typeof self&&self.Prism&&self.document&&Prism.hooks.add("complete",function(e){if(e.code){var t=e.element.parentNode,s=/\s*\bline-numbers\b\s*/;if(t&&/pre/i.test(t.nodeName)&&(s.test(t.className)||s.test(e.element.className))&&!e.element.querySelector(".line-numbers-rows")){s.test(e.element.className)&&(e.element.className=e.element.className.replace(s,"")),s.test(t.className)||(t.className+=" line-numbers");var n,a=e.code.match(/\n(?!$)/g),l=a?a.length+1:1,r=new Array(l+1);r=r.join("<span></span>"),n=document.createElement("span"),n.setAttribute("aria-hidden","true"),n.className="line-numbers-rows",n.innerHTML=r,t.hasAttribute("data-start")&&(t.style.counterReset="linenumber "+(parseInt(t.getAttribute("data-start"),10)-1)),e.element.appendChild(n)}}})}();
-!function(){if("undefined"!=typeof self&&self.Prism&&self.document){var t=[],e={},n=function(){};Prism.plugins.toolbar={};var a=Prism.plugins.toolbar.registerButton=function(n,a){var o;o="function"==typeof a?a:function(t){var e;return"function"==typeof a.onClick?(e=document.createElement("button"),e.type="button",e.addEventListener("click",function(){a.onClick.call(this,t)})):"string"==typeof a.url?(e=document.createElement("a"),e.href=a.url):e=document.createElement("span"),e.textContent=a.text,e},t.push(e[n]=o)},o=Prism.plugins.toolbar.hook=function(a){var o=a.element.parentNode;if(o&&/pre/i.test(o.nodeName)&&!o.classList.contains("code-toolbar")){o.classList.add("code-toolbar");var r=document.createElement("div");r.classList.add("toolbar"),document.body.hasAttribute("data-toolbar-order")&&(t=document.body.getAttribute("data-toolbar-order").split(",").map(function(t){return e[t]||n})),t.forEach(function(t){var e=t(a);if(e){var n=document.createElement("div");n.classList.add("toolbar-item"),n.appendChild(e),r.appendChild(n)}}),o.appendChild(r)}};a("label",function(t){var e=t.element.parentNode;if(e&&/pre/i.test(e.nodeName)&&e.hasAttribute("data-label")){var n,a,o=e.getAttribute("data-label");try{a=document.querySelector("template#"+o)}catch(r){}return a?n=a.content:(e.hasAttribute("data-url")?(n=document.createElement("a"),n.href=e.getAttribute("data-url")):n=document.createElement("span"),n.textContent=o),n}}),Prism.hooks.add("complete",o)}}();
-!function(){if("undefined"!=typeof self&&self.Prism&&self.document){if(!Prism.plugins.toolbar)return console.warn("Show Languages plugin loaded before Toolbar plugin."),void 0;var e={html:"HTML",xml:"XML",svg:"SVG",mathml:"MathML",css:"CSS",clike:"C-like",javascript:"JavaScript",abap:"ABAP",actionscript:"ActionScript",apacheconf:"Apache Configuration",apl:"APL",applescript:"AppleScript",asciidoc:"AsciiDoc",aspnet:"ASP.NET (C#)",autoit:"AutoIt",autohotkey:"AutoHotkey",basic:"BASIC",csharp:"C#",cpp:"C++",coffeescript:"CoffeeScript","css-extras":"CSS Extras",fsharp:"F#",glsl:"GLSL",graphql:"GraphQL",http:"HTTP",inform7:"Inform 7",json:"JSON",latex:"LaTeX",livescript:"LiveScript",lolcode:"LOLCODE",matlab:"MATLAB",mel:"MEL",nasm:"NASM",nginx:"nginx",nsis:"NSIS",objectivec:"Objective-C",ocaml:"OCaml",parigp:"PARI/GP",php:"PHP","php-extras":"PHP Extras",powershell:"PowerShell",properties:".properties",protobuf:"Protocol Buffers",jsx:"React JSX",rest:"reST (reStructuredText)",sas:"SAS",sass:"Sass (Sass)",scss:"Sass (Scss)",sql:"SQL",typescript:"TypeScript",vhdl:"VHDL",vim:"vim",wiki:"Wiki markup",xojo:"Xojo (REALbasic)",yaml:"YAML"};Prism.plugins.toolbar.registerButton("show-language",function(t){var a=t.element.parentNode;if(a&&/pre/i.test(a.nodeName)){var s=a.getAttribute("data-language")||e[t.language]||t.language.substring(0,1).toUpperCase()+t.language.substring(1),r=document.createElement("span");return r.textContent=s,r}})}}();
-!function(){if("undefined"!=typeof self&&self.Prism&&self.document){if(!Prism.plugins.toolbar)return console.warn("Copy to Clipboard plugin loaded before Toolbar plugin."),void 0;var o=window.Clipboard||void 0;o||"function"!=typeof require||(o=require("clipboard"));var e=[];if(!o){var t=document.createElement("script"),n=document.querySelector("head");t.onload=function(){if(o=window.Clipboard)for(;e.length;)e.pop()()},t.src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.5.8/clipboard.min.js",n.appendChild(t)}Prism.plugins.toolbar.registerButton("copy-to-clipboard",function(t){function n(){var e=new o(i,{text:function(){return t.code}});e.on("success",function(){i.textContent="Copied!",r()}),e.on("error",function(){i.textContent="Press Ctrl+C to copy",r()})}function r(){setTimeout(function(){i.textContent="Copy"},5e3)}var i=document.createElement("a");return i.textContent="Copy",o?n():e.push(n),i})}}();
+var _self =
+    'undefined' != typeof window
+      ? window
+      : 'undefined' != typeof WorkerGlobalScope &&
+        self instanceof WorkerGlobalScope
+        ? self
+        : {},
+  Prism = (function() {
+    var e = /\blang(?:uage)?-(\w+)\b/i,
+      t = 0,
+      n = (_self.Prism = {
+        util: {
+          encode: function(e) {
+            return e instanceof a
+              ? new a(e.type, n.util.encode(e.content), e.alias)
+              : 'Array' === n.util.type(e)
+                ? e.map(n.util.encode)
+                : e
+                    .replace(/&/g, '&amp;')
+                    .replace(/</g, '&lt;')
+                    .replace(/\u00a0/g, ' ')
+          },
+          type: function(e) {
+            return Object.prototype.toString
+              .call(e)
+              .match(/\[object (\w+)\]/)[1]
+          },
+          objId: function(e) {
+            return (
+              e.__id || Object.defineProperty(e, '__id', { value: ++t }), e.__id
+            )
+          },
+          clone: function(e) {
+            var t = n.util.type(e)
+            switch (t) {
+              case 'Object':
+                var a = {}
+                for (var r in e)
+                  e.hasOwnProperty(r) && (a[r] = n.util.clone(e[r]))
+                return a
+              case 'Array':
+                return (
+                  e.map &&
+                  e.map(function(e) {
+                    return n.util.clone(e)
+                  })
+                )
+            }
+            return e
+          },
+        },
+        languages: {
+          extend: function(e, t) {
+            var a = n.util.clone(n.languages[e])
+            for (var r in t) a[r] = t[r]
+            return a
+          },
+          insertBefore: function(e, t, a, r) {
+            r = r || n.languages
+            var i = r[e]
+            if (2 == arguments.length) {
+              a = arguments[1]
+              for (var l in a) a.hasOwnProperty(l) && (i[l] = a[l])
+              return i
+            }
+            var o = {}
+            for (var s in i)
+              if (i.hasOwnProperty(s)) {
+                if (s == t)
+                  for (var l in a) a.hasOwnProperty(l) && (o[l] = a[l])
+                o[s] = i[s]
+              }
+            return (
+              n.languages.DFS(n.languages, function(t, n) {
+                n === r[e] && t != e && (this[t] = o)
+              }),
+              (r[e] = o)
+            )
+          },
+          DFS: function(e, t, a, r) {
+            r = r || {}
+            for (var i in e)
+              e.hasOwnProperty(i) &&
+                (t.call(e, i, e[i], a || i),
+                'Object' !== n.util.type(e[i]) || r[n.util.objId(e[i])]
+                  ? 'Array' !== n.util.type(e[i]) ||
+                    r[n.util.objId(e[i])] ||
+                    ((r[n.util.objId(e[i])] = !0),
+                    n.languages.DFS(e[i], t, i, r))
+                  : ((r[n.util.objId(e[i])] = !0),
+                    n.languages.DFS(e[i], t, null, r)))
+          },
+        },
+        plugins: {},
+        highlightAll: function(e, t) {
+          var a = {
+            callback: t,
+            selector:
+              'code[class*="language-"], [class*="language-"] code, code[class*="lang-"], [class*="lang-"] code',
+          }
+          n.hooks.run('before-highlightall', a)
+          for (
+            var r,
+              i = a.elements || document.querySelectorAll(a.selector),
+              l = 0;
+            (r = i[l++]);
+
+          )
+            n.highlightElement(r, e === !0, a.callback)
+        },
+        highlightElement: function(t, a, r) {
+          for (var i, l, o = t; o && !e.test(o.className); ) o = o.parentNode
+          o &&
+            ((i = (o.className.match(e) || [, ''])[1].toLowerCase()),
+            (l = n.languages[i])),
+            (t.className =
+              t.className.replace(e, '').replace(/\s+/g, ' ') +
+              ' language-' +
+              i),
+            (o = t.parentNode),
+            /pre/i.test(o.nodeName) &&
+              (o.className =
+                o.className.replace(e, '').replace(/\s+/g, ' ') +
+                ' language-' +
+                i)
+          var s = t.textContent,
+            u = { element: t, language: i, grammar: l, code: s }
+          if ((n.hooks.run('before-sanity-check', u), !u.code || !u.grammar))
+            return n.hooks.run('complete', u), void 0
+          if ((n.hooks.run('before-highlight', u), a && _self.Worker)) {
+            var g = new Worker(n.filename)
+            ;(g.onmessage = function(e) {
+              ;(u.highlightedCode = e.data),
+                n.hooks.run('before-insert', u),
+                (u.element.innerHTML = u.highlightedCode),
+                r && r.call(u.element),
+                n.hooks.run('after-highlight', u),
+                n.hooks.run('complete', u)
+            }),
+              g.postMessage(
+                JSON.stringify({
+                  language: u.language,
+                  code: u.code,
+                  immediateClose: !0,
+                }),
+              )
+          } else
+            (u.highlightedCode = n.highlight(u.code, u.grammar, u.language)),
+              n.hooks.run('before-insert', u),
+              (u.element.innerHTML = u.highlightedCode),
+              r && r.call(t),
+              n.hooks.run('after-highlight', u),
+              n.hooks.run('complete', u)
+        },
+        highlight: function(e, t, r) {
+          var i = n.tokenize(e, t)
+          return a.stringify(n.util.encode(i), r)
+        },
+        tokenize: function(e, t) {
+          var a = n.Token,
+            r = [e],
+            i = t.rest
+          if (i) {
+            for (var l in i) t[l] = i[l]
+            delete t.rest
+          }
+          e: for (var l in t)
+            if (t.hasOwnProperty(l) && t[l]) {
+              var o = t[l]
+              o = 'Array' === n.util.type(o) ? o : [o]
+              for (var s = 0; s < o.length; ++s) {
+                var u = o[s],
+                  g = u.inside,
+                  c = !!u.lookbehind,
+                  h = !!u.greedy,
+                  f = 0,
+                  d = u.alias
+                if (h && !u.pattern.global) {
+                  var p = u.pattern.toString().match(/[imuy]*$/)[0]
+                  u.pattern = RegExp(u.pattern.source, p + 'g')
+                }
+                u = u.pattern || u
+                for (var m = 0, y = 0; m < r.length; y += r[m].length, ++m) {
+                  var v = r[m]
+                  if (r.length > e.length) break e
+                  if (!(v instanceof a)) {
+                    u.lastIndex = 0
+                    var b = u.exec(v),
+                      k = 1
+                    if (!b && h && m != r.length - 1) {
+                      if (((u.lastIndex = y), (b = u.exec(e)), !b)) break
+                      for (
+                        var w = b.index + (c ? b[1].length : 0),
+                          _ = b.index + b[0].length,
+                          A = m,
+                          P = y,
+                          j = r.length;
+                        j > A && _ > P;
+                        ++A
+                      )
+                        (P += r[A].length), w >= P && (++m, (y = P))
+                      if (r[m] instanceof a || r[A - 1].greedy) continue
+                      ;(k = A - m), (v = e.slice(y, P)), (b.index -= y)
+                    }
+                    if (b) {
+                      c && (f = b[1].length)
+                      var w = b.index + f,
+                        b = b[0].slice(f),
+                        _ = w + b.length,
+                        O = v.slice(0, w),
+                        x = v.slice(_),
+                        S = [m, k]
+                      O && S.push(O)
+                      var N = new a(l, g ? n.tokenize(b, g) : b, d, b, h)
+                      S.push(N),
+                        x && S.push(x),
+                        Array.prototype.splice.apply(r, S)
+                    }
+                  }
+                }
+              }
+            }
+          return r
+        },
+        hooks: {
+          all: {},
+          add: function(e, t) {
+            var a = n.hooks.all
+            ;(a[e] = a[e] || []), a[e].push(t)
+          },
+          run: function(e, t) {
+            var a = n.hooks.all[e]
+            if (a && a.length) for (var r, i = 0; (r = a[i++]); ) r(t)
+          },
+        },
+      }),
+      a = (n.Token = function(e, t, n, a, r) {
+        ;(this.type = e),
+          (this.content = t),
+          (this.alias = n),
+          (this.length = 0 | (a || '').length),
+          (this.greedy = !!r)
+      })
+    if (
+      ((a.stringify = function(e, t, r) {
+        if ('string' == typeof e) return e
+        if ('Array' === n.util.type(e))
+          return e
+            .map(function(n) {
+              return a.stringify(n, t, e)
+            })
+            .join('')
+        var i = {
+          type: e.type,
+          content: a.stringify(e.content, t, r),
+          tag: 'span',
+          classes: ['token', e.type],
+          attributes: {},
+          language: t,
+          parent: r,
+        }
+        if (
+          ('comment' == i.type && (i.attributes.spellcheck = 'true'), e.alias)
+        ) {
+          var l = 'Array' === n.util.type(e.alias) ? e.alias : [e.alias]
+          Array.prototype.push.apply(i.classes, l)
+        }
+        n.hooks.run('wrap', i)
+        var o = Object.keys(i.attributes)
+          .map(function(e) {
+            return (
+              e + '="' + (i.attributes[e] || '').replace(/"/g, '&quot;') + '"'
+            )
+          })
+          .join(' ')
+        return (
+          '<' +
+          i.tag +
+          ' class="' +
+          i.classes.join(' ') +
+          '"' +
+          (o ? ' ' + o : '') +
+          '>' +
+          i.content +
+          '</' +
+          i.tag +
+          '>'
+        )
+      }),
+      !_self.document)
+    )
+      return _self.addEventListener
+        ? (_self.addEventListener(
+            'message',
+            function(e) {
+              var t = JSON.parse(e.data),
+                a = t.language,
+                r = t.code,
+                i = t.immediateClose
+              _self.postMessage(n.highlight(r, n.languages[a], a)),
+                i && _self.close()
+            },
+            !1,
+          ),
+          _self.Prism)
+        : _self.Prism
+    var r =
+      document.currentScript ||
+      [].slice.call(document.getElementsByTagName('script')).pop()
+    return (
+      r &&
+        ((n.filename = r.src),
+        document.addEventListener &&
+          !r.hasAttribute('data-manual') &&
+          ('loading' !== document.readyState
+            ? window.requestAnimationFrame
+              ? window.requestAnimationFrame(n.highlightAll)
+              : window.setTimeout(n.highlightAll, 16)
+            : document.addEventListener('DOMContentLoaded', n.highlightAll))),
+      _self.Prism
+    )
+  })()
+'undefined' != typeof module && module.exports && (module.exports = Prism),
+  'undefined' != typeof global && (global.Prism = Prism)
+;(Prism.languages.markup = {
+  comment: /<!--[\w\W]*?-->/,
+  prolog: /<\?[\w\W]+?\?>/,
+  doctype: /<!DOCTYPE[\w\W]+?>/i,
+  cdata: /<!\[CDATA\[[\w\W]*?]]>/i,
+  tag: {
+    pattern: /<\/?(?!\d)[^\s>\/=$<]+(?:\s+[^\s>\/=]+(?:=(?:("|')(?:\\\1|\\?(?!\1)[\w\W])*\1|[^\s'">=]+))?)*\s*\/?>/i,
+    inside: {
+      tag: {
+        pattern: /^<\/?[^\s>\/]+/i,
+        inside: { punctuation: /^<\/?/, namespace: /^[^\s>\/:]+:/ },
+      },
+      'attr-value': {
+        pattern: /=(?:('|")[\w\W]*?(\1)|[^\s>]+)/i,
+        inside: { punctuation: /[=>"']/ },
+      },
+      punctuation: /\/?>/,
+      'attr-name': {
+        pattern: /[^\s>\/]+/,
+        inside: { namespace: /^[^\s>\/:]+:/ },
+      },
+    },
+  },
+  entity: /&#?[\da-z]{1,8};/i,
+}),
+  Prism.hooks.add('wrap', function(a) {
+    'entity' === a.type &&
+      (a.attributes.title = a.content.replace(/&amp;/, '&'))
+  }),
+  (Prism.languages.xml = Prism.languages.markup),
+  (Prism.languages.html = Prism.languages.markup),
+  (Prism.languages.mathml = Prism.languages.markup),
+  (Prism.languages.svg = Prism.languages.markup)
+;(Prism.languages.css = {
+  comment: /\/\*[\w\W]*?\*\//,
+  atrule: { pattern: /@[\w-]+?.*?(;|(?=\s*\{))/i, inside: { rule: /@[\w-]+/ } },
+  url: /url\((?:(["'])(\\(?:\r\n|[\w\W])|(?!\1)[^\\\r\n])*\1|.*?)\)/i,
+  selector: /[^\{\}\s][^\{\};]*?(?=\s*\{)/,
+  string: {
+    pattern: /("|')(\\(?:\r\n|[\w\W])|(?!\1)[^\\\r\n])*\1/,
+    greedy: !0,
+  },
+  property: /(\b|\B)[\w-]+(?=\s*:)/i,
+  important: /\B!important\b/i,
+  function: /[-a-z0-9]+(?=\()/i,
+  punctuation: /[(){};:]/,
+}),
+  (Prism.languages.css.atrule.inside.rest = Prism.util.clone(
+    Prism.languages.css,
+  )),
+  Prism.languages.markup &&
+    (Prism.languages.insertBefore('markup', 'tag', {
+      style: {
+        pattern: /(<style[\w\W]*?>)[\w\W]*?(?=<\/style>)/i,
+        lookbehind: !0,
+        inside: Prism.languages.css,
+        alias: 'language-css',
+      },
+    }),
+    Prism.languages.insertBefore(
+      'inside',
+      'attr-value',
+      {
+        'style-attr': {
+          pattern: /\s*style=("|').*?\1/i,
+          inside: {
+            'attr-name': {
+              pattern: /^\s*style/i,
+              inside: Prism.languages.markup.tag.inside,
+            },
+            punctuation: /^\s*=\s*['"]|['"]\s*$/,
+            'attr-value': { pattern: /.+/i, inside: Prism.languages.css },
+          },
+          alias: 'language-css',
+        },
+      },
+      Prism.languages.markup.tag,
+    ))
+Prism.languages.clike = {
+  comment: [
+    { pattern: /(^|[^\\])\/\*[\w\W]*?\*\//, lookbehind: !0 },
+    { pattern: /(^|[^\\:])\/\/.*/, lookbehind: !0 },
+  ],
+  string: {
+    pattern: /(["'])(\\(?:\r\n|[\s\S])|(?!\1)[^\\\r\n])*\1/,
+    greedy: !0,
+  },
+  'class-name': {
+    pattern: /((?:\b(?:class|interface|extends|implements|trait|instanceof|new)\s+)|(?:catch\s+\())[a-z0-9_\.\\]+/i,
+    lookbehind: !0,
+    inside: { punctuation: /(\.|\\)/ },
+  },
+  keyword: /\b(if|else|while|do|for|return|in|instanceof|function|new|try|throw|catch|finally|null|break|continue)\b/,
+  boolean: /\b(true|false)\b/,
+  function: /[a-z0-9_]+(?=\()/i,
+  number: /\b-?(?:0x[\da-f]+|\d*\.?\d+(?:e[+-]?\d+)?)\b/i,
+  operator: /--?|\+\+?|!=?=?|<=?|>=?|==?=?|&&?|\|\|?|\?|\*|\/|~|\^|%/,
+  punctuation: /[{}[\];(),.:]/,
+}
+;(Prism.languages.javascript = Prism.languages.extend('clike', {
+  keyword: /\b(as|async|await|break|case|catch|class|const|continue|debugger|default|delete|do|else|enum|export|extends|finally|for|from|function|get|if|implements|import|in|instanceof|interface|let|new|null|of|package|private|protected|public|return|set|static|super|switch|this|throw|try|typeof|var|void|while|with|yield)\b/,
+  number: /\b-?(0x[\dA-Fa-f]+|0b[01]+|0o[0-7]+|\d*\.?\d+([Ee][+-]?\d+)?|NaN|Infinity)\b/,
+  function: /[_$a-zA-Z\xA0-\uFFFF][_$a-zA-Z0-9\xA0-\uFFFF]*(?=\()/i,
+  operator: /--?|\+\+?|!=?=?|<=?|>=?|==?=?|&&?|\|\|?|\?|\*\*?|\/|~|\^|%|\.{3}/,
+})),
+  Prism.languages.insertBefore('javascript', 'keyword', {
+    regex: {
+      pattern: /(^|[^\/])\/(?!\/)(\[.+?]|\\.|[^\/\\\r\n])+\/[gimyu]{0,5}(?=\s*($|[\r\n,.;})]))/,
+      lookbehind: !0,
+      greedy: !0,
+    },
+  }),
+  Prism.languages.insertBefore('javascript', 'string', {
+    'template-string': {
+      pattern: /`(?:\\\\|\\?[^\\])*?`/,
+      greedy: !0,
+      inside: {
+        interpolation: {
+          pattern: /\$\{[^}]+\}/,
+          inside: {
+            'interpolation-punctuation': {
+              pattern: /^\$\{|\}$/,
+              alias: 'punctuation',
+            },
+            rest: Prism.languages.javascript,
+          },
+        },
+        string: /[\s\S]+/,
+      },
+    },
+  }),
+  Prism.languages.markup &&
+    Prism.languages.insertBefore('markup', 'tag', {
+      script: {
+        pattern: /(<script[\w\W]*?>)[\w\W]*?(?=<\/script>)/i,
+        lookbehind: !0,
+        inside: Prism.languages.javascript,
+        alias: 'language-javascript',
+      },
+    }),
+  (Prism.languages.js = Prism.languages.javascript)
+!(function() {
+  'undefined' != typeof self &&
+    self.Prism &&
+    self.document &&
+    Prism.hooks.add('complete', function(e) {
+      if (e.code) {
+        var t = e.element.parentNode,
+          s = /\s*\bline-numbers\b\s*/
+        if (
+          t &&
+          /pre/i.test(t.nodeName) &&
+          (s.test(t.className) || s.test(e.element.className)) &&
+          !e.element.querySelector('.line-numbers-rows')
+        ) {
+          s.test(e.element.className) &&
+            (e.element.className = e.element.className.replace(s, '')),
+            s.test(t.className) || (t.className += ' line-numbers')
+          var n,
+            a = e.code.match(/\n(?!$)/g),
+            l = a ? a.length + 1 : 1,
+            r = new Array(l + 1)
+          ;(r = r.join('<span></span>')),
+            (n = document.createElement('span')),
+            n.setAttribute('aria-hidden', 'true'),
+            (n.className = 'line-numbers-rows'),
+            (n.innerHTML = r),
+            t.hasAttribute('data-start') &&
+              (t.style.counterReset =
+                'linenumber ' +
+                (parseInt(t.getAttribute('data-start'), 10) - 1)),
+            e.element.appendChild(n)
+        }
+      }
+    })
+})()
+!(function() {
+  if ('undefined' != typeof self && self.Prism && self.document) {
+    var t = [],
+      e = {},
+      n = function() {}
+    Prism.plugins.toolbar = {}
+    var a = (Prism.plugins.toolbar.registerButton = function(n, a) {
+        var o
+        ;(o =
+          'function' == typeof a
+            ? a
+            : function(t) {
+                var e
+                return (
+                  'function' == typeof a.onClick
+                    ? ((e = document.createElement('button')),
+                      (e.type = 'button'),
+                      e.addEventListener('click', function() {
+                        a.onClick.call(this, t)
+                      }))
+                    : 'string' == typeof a.url
+                      ? ((e = document.createElement('a')), (e.href = a.url))
+                      : (e = document.createElement('span')),
+                  (e.textContent = a.text),
+                  e
+                )
+              }),
+          t.push((e[n] = o))
+      }),
+      o = (Prism.plugins.toolbar.hook = function(a) {
+        var o = a.element.parentNode
+        if (
+          o &&
+          /pre/i.test(o.nodeName) &&
+          !o.classList.contains('code-toolbar')
+        ) {
+          o.classList.add('code-toolbar')
+          var r = document.createElement('div')
+          r.classList.add('toolbar'),
+            document.body.hasAttribute('data-toolbar-order') &&
+              (t = document.body
+                .getAttribute('data-toolbar-order')
+                .split(',')
+                .map(function(t) {
+                  return e[t] || n
+                })),
+            t.forEach(function(t) {
+              var e = t(a)
+              if (e) {
+                var n = document.createElement('div')
+                n.classList.add('toolbar-item'),
+                  n.appendChild(e),
+                  r.appendChild(n)
+              }
+            }),
+            o.appendChild(r)
+        }
+      })
+    a('label', function(t) {
+      var e = t.element.parentNode
+      if (e && /pre/i.test(e.nodeName) && e.hasAttribute('data-label')) {
+        var n,
+          a,
+          o = e.getAttribute('data-label')
+        try {
+          a = document.querySelector('template#' + o)
+        } catch (r) {}
+        return (
+          a
+            ? (n = a.content)
+            : (e.hasAttribute('data-url')
+                ? ((n = document.createElement('a')),
+                  (n.href = e.getAttribute('data-url')))
+                : (n = document.createElement('span')),
+              (n.textContent = o)),
+          n
+        )
+      }
+    }),
+      Prism.hooks.add('complete', o)
+  }
+})()
+!(function() {
+  if ('undefined' != typeof self && self.Prism && self.document) {
+    if (!Prism.plugins.toolbar)
+      return (
+        console.warn('Show Languages plugin loaded before Toolbar plugin.'),
+        void 0
+      )
+    var e = {
+      html: 'HTML',
+      xml: 'XML',
+      svg: 'SVG',
+      mathml: 'MathML',
+      css: 'CSS',
+      clike: 'C-like',
+      javascript: 'JavaScript',
+      abap: 'ABAP',
+      actionscript: 'ActionScript',
+      apacheconf: 'Apache Configuration',
+      apl: 'APL',
+      applescript: 'AppleScript',
+      asciidoc: 'AsciiDoc',
+      aspnet: 'ASP.NET (C#)',
+      autoit: 'AutoIt',
+      autohotkey: 'AutoHotkey',
+      basic: 'BASIC',
+      csharp: 'C#',
+      cpp: 'C++',
+      coffeescript: 'CoffeeScript',
+      'css-extras': 'CSS Extras',
+      fsharp: 'F#',
+      glsl: 'GLSL',
+      graphql: 'GraphQL',
+      http: 'HTTP',
+      inform7: 'Inform 7',
+      json: 'JSON',
+      latex: 'LaTeX',
+      livescript: 'LiveScript',
+      lolcode: 'LOLCODE',
+      matlab: 'MATLAB',
+      mel: 'MEL',
+      nasm: 'NASM',
+      nginx: 'nginx',
+      nsis: 'NSIS',
+      objectivec: 'Objective-C',
+      ocaml: 'OCaml',
+      parigp: 'PARI/GP',
+      php: 'PHP',
+      'php-extras': 'PHP Extras',
+      powershell: 'PowerShell',
+      properties: '.properties',
+      protobuf: 'Protocol Buffers',
+      jsx: 'React JSX',
+      rest: 'reST (reStructuredText)',
+      sas: 'SAS',
+      sass: 'Sass (Sass)',
+      scss: 'Sass (Scss)',
+      sql: 'SQL',
+      typescript: 'TypeScript',
+      vhdl: 'VHDL',
+      vim: 'vim',
+      wiki: 'Wiki markup',
+      xojo: 'Xojo (REALbasic)',
+      yaml: 'YAML',
+    }
+    Prism.plugins.toolbar.registerButton('show-language', function(t) {
+      var a = t.element.parentNode
+      if (a && /pre/i.test(a.nodeName)) {
+        var s =
+            a.getAttribute('data-language') ||
+            e[t.language] ||
+            t.language.substring(0, 1).toUpperCase() + t.language.substring(1),
+          r = document.createElement('span')
+        return (r.textContent = s), r
+      }
+    })
+  }
+})()
+!(function() {
+  if ('undefined' != typeof self && self.Prism && self.document) {
+    if (!Prism.plugins.toolbar)
+      return (
+        console.warn('Copy to Clipboard plugin loaded before Toolbar plugin.'),
+        void 0
+      )
+    var o = window.Clipboard || void 0
+    o || 'function' != typeof require || (o = require('clipboard'))
+    var e = []
+    if (!o) {
+      var t = document.createElement('script'),
+        n = document.querySelector('head')
+      ;(t.onload = function() {
+        if ((o = window.Clipboard)) for (; e.length; ) e.pop()()
+      }),
+        (t.src =
+          'https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.5.8/clipboard.min.js'),
+        n.appendChild(t)
+    }
+    Prism.plugins.toolbar.registerButton('copy-to-clipboard', function(t) {
+      function n() {
+        var e = new o(i, {
+          text: function() {
+            return t.code
+          },
+        })
+        e.on('success', function() {
+          ;(i.textContent = 'Copied!'), r()
+        }),
+          e.on('error', function() {
+            ;(i.textContent = 'Press Ctrl+C to copy'), r()
+          })
+      }
+      function r() {
+        setTimeout(function() {
+          i.textContent = 'Copy'
+        }, 5e3)
+      }
+      var i = document.createElement('a')
+      return (i.textContent = 'Copy'), o ? n() : e.push(n), i
+    })
+  }
+})()

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,44 +1,48 @@
-import { merge, skip } from './utils';
-
+import { merge, skip } from './utils'
 
 export default class Config {
   constructor(config = {}) {
-    this._config   = { headers: {} };
+    this._config = { headers: {} }
 
-    this.set(config);
+    this.set(config)
   }
 
   merge(...configParams) {
-    const params = merge(...configParams);
+    const params = merge(...configParams)
 
     const config = merge(
       this.skipNotUsedMethods(params.method),
       this._config[params.method],
-      params
-    );
+      params,
+    )
 
     if (
       typeof config.body === 'object' &&
       config.headers &&
       config.headers['Content-Type'] === 'application/json'
     ) {
-      config.body = JSON.stringify(config.body);
+      config.body = JSON.stringify(config.body)
     }
-    return config;
+    return config
   }
 
   skipNotUsedMethods(currentMethod) {
-    const notUsedMethods = ['delete', 'get', 'head', 'patch', 'post', 'put']
-      .filter(method => currentMethod !== method.toLowerCase());
-    return skip(this._config, notUsedMethods);
+    const notUsedMethods = [
+      'delete',
+      'get',
+      'head',
+      'patch',
+      'post',
+      'put',
+    ].filter((method) => currentMethod !== method.toLowerCase())
+    return skip(this._config, notUsedMethods)
   }
 
-
   set(config) {
-    this._config = merge(this._config, config);
+    this._config = merge(this._config, config)
   }
 
   get() {
-    return merge(this._config);
+    return merge(this._config)
   }
 }

--- a/lib/helpers/response-handler.js
+++ b/lib/helpers/response-handler.js
@@ -1,59 +1,56 @@
 // Reader :: 'arrayBuffer' | 'blob' | 'formData' | 'json' | 'text' | 'raw'
-const READERS = ['arrayBuffer', 'blob', 'formData', 'json', 'text', 'raw'];
+const READERS = ['arrayBuffer', 'blob', 'formData', 'json', 'text', 'raw']
 
 // validateReader :: Reader -> Bool
-const validateReader = reader => READERS.includes(reader);
+const validateReader = (reader) => READERS.includes(reader)
 
 // defineReader :: Bool -> Headers -> String -> String
 function defineReader(ok, headers, reader) {
   if (ok && validateReader(reader)) {
-    return reader;
+    return reader
   }
 
-  const contentType = headers.get('Content-Type') || '';
-  return contentType.includes('application/json')
-    ? 'json'
-    : 'text';
+  const contentType = headers.get('Content-Type') || ''
+  return contentType.includes('application/json') ? 'json' : 'text'
 }
 
 // upgradeResponse :: Response -> Object -> Promise
 function upgradeResponse(response, obj) {
-  const { ok, headers, status, statusText } = response;
-  const { config: { bodyType } } = obj;
+  const { ok, headers, status, statusText } = response
+  const { config: { bodyType } } = obj
 
-  obj.headers    = headers;
-  obj.status     = status;
-  obj.statusText = statusText;
+  obj.headers = headers
+  obj.status = status
+  obj.statusText = statusText
 
-  const reader = defineReader(ok, headers, bodyType);
+  const reader = defineReader(ok, headers, bodyType)
 
   if (reader === 'raw') {
-    obj.data = response.body;
-    return Promise.resolve(obj);
+    obj.data = response.body
+    return Promise.resolve(obj)
   }
 
   if (response.body === undefined) {
-    obj.data = undefined;
-    return Promise.resolve(obj);
+    obj.data = undefined
+    return Promise.resolve(obj)
   }
 
-  return response[reader]()
-    .then((data) => {
-      obj.data = data;
-      return obj;
-    });
+  return response[reader]().then((data) => {
+    obj.data = data
+    return obj
+  })
 }
 
 // Reads or rejects a fetch response
 // responseHandler :: Response -> Object -> Promise
 export default function responseHandler(response, config) {
   if (!response.ok) {
-    const err  = new Error(response.statusText);
-    err.config = config;
-    return upgradeResponse(response, err)
-      .then((e) => { throw e; });
+    const err = new Error(response.statusText)
+    err.config = config
+    return upgradeResponse(response, err).then((e) => {
+      throw e
+    })
   }
 
-  return upgradeResponse(response, { config });
+  return upgradeResponse(response, { config })
 }
-

--- a/lib/helpers/url-handler.js
+++ b/lib/helpers/url-handler.js
@@ -1,4 +1,4 @@
-import { stringify as stringifyParams } from 'qs';
+import { stringify as stringifyParams } from 'qs'
 
 /**
  * Stringify and concats params to the provided URL
@@ -9,9 +9,7 @@ import { stringify as stringifyParams } from 'qs';
  */
 
 export function concatParams(URL, params) {
-  return params
-    ? `${URL}?${stringifyParams(params)}`.replace(/\?$/, '')
-    : URL;
+  return params ? `${URL}?${stringifyParams(params)}`.replace(/\?$/, '') : URL
 }
 
 /**
@@ -23,7 +21,7 @@ export function concatParams(URL, params) {
  */
 
 export function combine(baseURL, relativeURL) {
-  return `${baseURL.replace(/\/+$/, '')}/${relativeURL.replace(/^\/+/, '')}`;
+  return `${baseURL.replace(/\/+$/, '')}/${relativeURL.replace(/^\/+/, '')}`
 }
 
 /**
@@ -36,7 +34,7 @@ export function isAbsolute(url) {
   // A URL is considered absolute if it begins with "<scheme>://" or "//" (protocol-relative URL).
   // RFC 3986 defines scheme name as a sequence of characters beginning with a letter and followed
   // by any combination of letters, digits, plus, period, or hyphen.
-  return /^([a-z][a-z\d\+\-\.]*:)?\/\//i.test(url);
+  return /^([a-z][a-z\d\+\-\.]*:)?\/\//i.test(url)
 }
 
 /**
@@ -50,8 +48,8 @@ export function isAbsolute(url) {
  */
 export function format(baseUrl, relativeURL, params) {
   if (!baseUrl || isAbsolute(relativeURL)) {
-    return concatParams(relativeURL, params);
+    return concatParams(relativeURL, params)
   }
 
-  return concatParams(combine(baseUrl, relativeURL), params);
+  return concatParams(combine(baseUrl, relativeURL), params)
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,113 +1,116 @@
-import 'isomorphic-fetch';
+import 'isomorphic-fetch'
 
-import { format as formatUrl } from './helpers/url-handler';
-import { skip, merge }         from './utils';
-import Middleware              from './middleware';
-import Config                  from './config';
-import responseHandler         from './helpers/response-handler';
-import { version }             from '../package.json';
-
+import { format as formatUrl } from './helpers/url-handler'
+import { skip, merge } from './utils'
+import Middleware from './middleware'
+import Config from './config'
+import responseHandler from './helpers/response-handler'
+import { version } from '../package.json'
 
 class Trae {
   constructor(config = {}) {
-    this._middleware = new Middleware();
-    this._config     = new Config(skip(config, ['baseUrl']));
+    this._middleware = new Middleware()
+    this._config = new Config(skip(config, ['baseUrl']))
 
-    this.baseUrl(config.baseUrl || '');
-    this._initMethodsWithBody();
-    this._initMethodsWithNoBody();
-    this._initMiddlewareMethods();
+    this.baseUrl(config.baseUrl || '')
+    this._initMethodsWithBody()
+    this._initMethodsWithNoBody()
+    this._initMiddlewareMethods()
 
-    this.version = version;
+    this.version = version
   }
 
   create(config) {
-    const instance = new this.constructor(merge(this.defaults(), config));
-    const mapAfter = ({ fulfill, reject }) => instance.after(fulfill, reject);
-    this._middleware._before.forEach(instance.before);
-    this._middleware._after.forEach(mapAfter);
-    this._middleware._finally.forEach(instance.finally);
-    return instance;
+    const instance = new this.constructor(merge(this.defaults(), config))
+    const mapAfter = ({ fulfill, reject }) => instance.after(fulfill, reject)
+    this._middleware._before.forEach(instance.before)
+    this._middleware._after.forEach(mapAfter)
+    this._middleware._finally.forEach(instance.finally)
+    return instance
   }
 
   defaults(config) {
     if (typeof config === 'undefined') {
-      const defaults = this._config.get();
-      this.baseUrl() && (defaults.baseUrl = this.baseUrl());
-      return defaults;
+      const defaults = this._config.get()
+      this.baseUrl() && (defaults.baseUrl = this.baseUrl())
+      return defaults
     }
-    this._config.set(skip(config, ['baseUrl']));
-    config.baseUrl && this.baseUrl(config.baseUrl);
-    return this._config.get();
+    this._config.set(skip(config, ['baseUrl']))
+    config.baseUrl && this.baseUrl(config.baseUrl)
+    return this._config.get()
   }
 
   baseUrl(baseUrl) {
     if (typeof baseUrl === 'undefined') {
-      return this._baseUrl;
+      return this._baseUrl
     }
-    this._baseUrl = baseUrl;
-    return this._baseUrl;
+    this._baseUrl = baseUrl
+    return this._baseUrl
   }
 
   request(config = {}) {
-    config.method || (config.method = 'get');
-    const mergedConfig = this._config.merge(config);
-    const url          = formatUrl(this._baseUrl, config.url, config.params);
+    config.method || (config.method = 'get')
+    const mergedConfig = this._config.merge(config)
+    const url = formatUrl(this._baseUrl, config.url, config.params)
 
-    return this._fetch(url, mergedConfig);
+    return this._fetch(url, mergedConfig)
   }
 
-  _fetch(url, c) {
-    const config = merge(c, { method: c.method.toUpperCase() });
-    const resolveFinally = (...args) => this._middleware.resolveFinally(...args);
+  _fetch(url, originalConfig) {
+    const config = merge(originalConfig, {
+      method: originalConfig.method.toUpperCase(),
+    })
+    const resolveFinally = (...args) => this._middleware.resolveFinally(...args)
 
-    return this._middleware.resolveBefore(config)
-    .then(config => fetch(url, config))
-    .then(res => responseHandler(res, config))
-    .then(
-      res => this._middleware.resolveAfter(undefined, res),
-      err => this._middleware.resolveAfter(err)
-    )
-    .then(
-      res => Promise.resolve(resolveFinally(config, url)).then(() => res),
-      err => Promise.resolve(resolveFinally(config, url)).then(() => { throw err; })
-    );
+    return this._middleware
+      .resolveBefore(config)
+      .then((c) => fetch(url, c))
+      .then((res) => responseHandler(res, config))
+      .then(
+        (res) => this._middleware.resolveAfter(undefined, res),
+        (err) => this._middleware.resolveAfter(err),
+      )
+      .then(
+        (res) => Promise.resolve(resolveFinally(config, url)).then(() => res),
+        (err) =>
+          Promise.resolve(resolveFinally(config, url)).then(() => {
+            throw err
+          }),
+      )
   }
 
   _initMethodsWithNoBody() {
-    ['get', 'delete', 'head'].forEach((method) => {
+    ;['get', 'delete', 'head'].forEach((method) => {
       this[method] = (path, config = {}) => {
-        const url          = formatUrl(this._baseUrl, path, config.params);
-        const mergedConfig = this._config.merge(config, { method, url });
+        const url = formatUrl(this._baseUrl, path, config.params)
+        const mergedConfig = this._config.merge(config, { method, url })
 
-        return this._fetch(url, mergedConfig);
-      };
-    });
+        return this._fetch(url, mergedConfig)
+      }
+    })
   }
 
   _initMethodsWithBody() {
     const defaultConf = {
-      headers: { 'Content-Type': 'application/json' }
-    };
-
-    ['post', 'put', 'patch'].forEach((method) => {
-      this._config.set({ [method]: defaultConf });
+      headers: { 'Content-Type': 'application/json' },
+    }
+    ;['post', 'put', 'patch'].forEach((method) => {
+      this._config.set({ [method]: defaultConf })
 
       this[method] = (path, body = {}, config = {}) => {
-        const url          = formatUrl(this._baseUrl, path, config.params);
-        const mergedConfig = this._config.merge(config, { body, method, url });
+        const url = formatUrl(this._baseUrl, path, config.params)
+        const mergedConfig = this._config.merge(config, { body, method, url })
 
-        return this._fetch(url, mergedConfig);
-      };
-    });
+        return this._fetch(url, mergedConfig)
+      }
+    })
   }
 
   _initMiddlewareMethods() {
-    ['before', 'after', 'finally'].forEach((method) => {
-      this[method] = (...args) => this._middleware[method](...args);
-    });
+    ;['before', 'after', 'finally'].forEach((method) => {
+      this[method] = (...args) => this._middleware[method](...args)
+    })
   }
-
 }
 
-export default new Trae();
+export default new Trae()

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -1,41 +1,40 @@
-const identity  = response => response;
-const rejection = err => Promise.reject(err);
-
+const identity = (response) => response
+const rejection = (err) => Promise.reject(err)
 
 export default class Middleware {
   constructor() {
-    this._before  = [];
-    this._after   = [];
-    this._finally = [];
+    this._before = []
+    this._after = []
+    this._finally = []
   }
 
   before(fn) {
-    this._before.push(fn);
-    return this._before.length - 1;
+    this._before.push(fn)
+    return this._before.length - 1
   }
 
   after(fulfill = identity, reject = rejection) {
-    this._after.push({ fulfill, reject });
-    return this._after.length - 1;
+    this._after.push({ fulfill, reject })
+    return this._after.length - 1
   }
 
   finally(fn) {
-    this._finally.push(fn);
-    return this._finally.length - 1;
+    this._finally.push(fn)
+    return this._finally.length - 1
   }
 
   resolveBefore(config) {
-    const chain = (promise, task) => promise.then(task);
-    return this._before.reduce(chain, Promise.resolve(config));
+    const chain = (promise, task) => promise.then(task)
+    return this._before.reduce(chain, Promise.resolve(config))
   }
 
   resolveAfter(err, response) {
-    const chain   = (promise, task) => promise.then(task.fulfill, task.reject);
-    const initial = err ? Promise.reject(err) : Promise.resolve(response);
-    return this._after.reduce(chain, initial);
+    const chain = (promise, task) => promise.then(task.fulfill, task.reject)
+    const initial = err ? Promise.reject(err) : Promise.resolve(response)
+    return this._after.reduce(chain, initial)
   }
 
   resolveFinally(config, url) {
-    this._finally.forEach(task => task(config, url));
+    this._finally.forEach((task) => task(config, url))
   }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,4 @@
-import _merge from 'merge';
-
+import _merge from 'merge'
 
 /**
  * Recursively merge objects
@@ -7,8 +6,8 @@ import _merge from 'merge';
  * @param {Object} objects to merge
  * @return {Object} the merged objects
  */
-export function merge(...params)  {
-  return _merge.recursive(true, ...params);
+export function merge(...params) {
+  return _merge.recursive(true, ...params)
 }
 
 /**
@@ -19,12 +18,11 @@ export function merge(...params)  {
  * @return {Object} the object with the properties skipped
  */
 export function skip(obj, keys) {
-  const result = {};
+  const result = {}
   Object.keys(obj)
-    .filter(key => !keys.includes(key))
+    .filter((key) => !keys.includes(key))
     .forEach((key) => {
-      result[key] = obj[key];
-    });
-  return result;
+      result[key] = obj[key]
+    })
+  return result
 }
-

--- a/package.json
+++ b/package.json
@@ -29,19 +29,23 @@
   },
   "homepage": "https://github.com/huemul/trae#readme",
   "scripts": {
-    "test:docs": "chimi",
     "add": "all-contributors add",
     "contributors": "all-contributors generate",
     "build": "NODE_ENV=production node build/rollup.js",
     "build:dev": "node build/rollup.js",
     "docs": "http-server ./docs -o",
-    "test": "npm run eslint && jest --coverage --verbose",
+    "test": "npm run lint && jest --coverage --verbose",
     "test:w": "jest --watch --verbose",
+    "test:docs": "chimi",
     "check-cover": "open coverage/lcov-report/index.html",
     "check-bundle:cjs": "open stats/cjs-bundle-statistics.html",
     "check-bundle:umd": "open stats/umd-bundle-statistics.html",
+    "eslint-check": "eslint --print-config .eslintrc.js | eslint-config-prettier-check",
     "prepublish": "in-publish && ./scripts/publish.sh || echo 'just installing'",
-    "eslint": "eslint . --ext .js",
+    "lint": "eslint . --ext .js",
+    "format": "prettier --write '**/*.{js,json,md}'",
+    "format:changed": "pretty-quick",
+    "format:staged": "pretty-quick --staged",
     "release": "np"
   },
   "dependencies": {
@@ -60,6 +64,7 @@
     "coveralls": "^3.0.0",
     "eslint": "^3.16.0",
     "eslint-config-airbnb": "^14.1.0",
+    "eslint-config-prettier": "^2.9.0",
     "eslint-loader": "^1.6.1",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^4.0.0",
@@ -71,6 +76,8 @@
     "mkdirp": "^0.5.1",
     "np": "^2.14.1",
     "pre-commit": "^1.2.2",
+    "prettier": "^1.11.1",
+    "pretty-quick": "^1.4.1",
     "regenerator-runtime": "^0.11.1",
     "rollup": "^0.57.1",
     "rollup-plugin-babel": "^4.0.0-beta.2",
@@ -88,7 +95,8 @@
     "rollup-watch": "^4.3.1"
   },
   "pre-commit": [
-    "eslint",
+    "format:staged",
+    "lint",
     "test"
   ],
   "jest": {

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -1,113 +1,105 @@
 /* global describe it expect */
 
-import { merge } from '../lib/utils';
-import Config    from '../lib/config';
+import { merge } from '../lib/utils'
+import Config from '../lib/config'
 
-
-const defaults = { headers: {} };
+const defaults = { headers: {} }
 
 const configParams = {
-  mode       : 'no-cors',
-  credentials: 'same-origin'
-};
+  mode: 'no-cors',
+  credentials: 'same-origin',
+}
 
 function getConfigWithParams() {
-  return new Config(configParams);
+  return new Config(configParams)
 }
 
 describe('Config -> config', () => {
   it('initializes with the default fetch config', () => {
-    const config = new Config();
+    const config = new Config()
 
-    expect(config._config).toEqual(defaults);
-    expect(config.get()).toEqual(defaults);
-  });
+    expect(config._config).toEqual(defaults)
+    expect(config.get()).toEqual(defaults)
+  })
 
   it('initializes with the defaults merged with the provided config', () => {
-    const config = getConfigWithParams();
+    const config = getConfigWithParams()
 
-    expect(config.get()).toEqual(merge(defaults, configParams));
-  });
+    expect(config.get()).toEqual(merge(defaults, configParams))
+  })
 
   describe('set', () => {
-
     it('merges the provided config with this._config', () => {
-      const config = getConfigWithParams();
+      const config = getConfigWithParams()
       config.set({
         mode: 'cors',
         headers: {
-          'X-ACCESS-TOKEN': 'aasdljhf2kjrasdf2l3jrhn2'
-        }
-      });
+          'X-ACCESS-TOKEN': 'aasdljhf2kjrasdf2l3jrhn2',
+        },
+      })
 
-      expect(config._config).toMatchSnapshot();
-    });
-
-  });
+      expect(config._config).toMatchSnapshot()
+    })
+  })
 
   describe('get', () => {
-
     it('returns the merged _defaults and _config', () => {
-      const config = getConfigWithParams();
+      const config = getConfigWithParams()
       config.set({
         mode: 'cors',
         headers: {
-          'X-ACCESS-TOKE': 'aasdljhf2kjrasdf2l3jrhn2'
-        }
-      });
+          'X-ACCESS-TOKE': 'aasdljhf2kjrasdf2l3jrhn2',
+        },
+      })
 
-      expect(config.get()).toMatchSnapshot();
-    });
-
-  });
+      expect(config.get()).toMatchSnapshot()
+    })
+  })
 
   describe('merge', () => {
-
     it('returns body stringified according to Content-Type', () => {
-      const config = new Config();
+      const config = new Config()
 
-      const actual = config.merge({ body: { foo: 'bar' } });
-      expect(actual).toMatchSnapshot();
-    });
-
-    it('returns the config merged with the params', () => {
-      const config = new Config({ mode: 'no-cors' });
-
-      const actual = config.merge({ credentials: 'same-origin' });
-      expect(actual).toMatchSnapshot();
-    });
+      const actual = config.merge({ body: { foo: 'bar' } })
+      expect(actual).toMatchSnapshot()
+    })
 
     it('returns the config merged with the params', () => {
-      const config = new Config({ mode: 'no-cors' });
+      const config = new Config({ mode: 'no-cors' })
 
-      const actual = config.merge({ credentials: 'same-origin' });
-      expect(actual).toMatchSnapshot();
-    });
+      const actual = config.merge({ credentials: 'same-origin' })
+      expect(actual).toMatchSnapshot()
+    })
+
+    it('returns the config merged with the params', () => {
+      const config = new Config({ mode: 'no-cors' })
+
+      const actual = config.merge({ credentials: 'same-origin' })
+      expect(actual).toMatchSnapshot()
+    })
 
     it('merges all the params passed', () => {
-      const config = new Config({ mode: 'no-cors' });
+      const config = new Config({ mode: 'no-cors' })
 
       const actual = config.merge(
         { credentials: 'same-origin' },
-        { headers: { 'Content-Type': 'text/plain' } }
-      );
-      expect(actual).toMatchSnapshot();
-    });
+        { headers: { 'Content-Type': 'text/plain' } },
+      )
+      expect(actual).toMatchSnapshot()
+    })
 
     it('does not mutate _config or _defaults', () => {
-      const config = new Config({ mode: 'no-cors' });
+      const config = new Config({ mode: 'no-cors' })
 
-      expect(config._config).toEqual({ headers: {}, mode: 'no-cors' });
+      expect(config._config).toEqual({ headers: {}, mode: 'no-cors' })
 
       const actual = config.merge(
         { headers: { 'Content-Type': 'text/plain' } },
-        { mode: 'cors' }
-      );
-      expect(actual).toMatchSnapshot();
+        { mode: 'cors' },
+      )
+      expect(actual).toMatchSnapshot()
 
-      expect(config._config).toEqual({ headers: {}, mode: 'no-cors' });
-    });
-
-  });
-
-});
+      expect(config._config).toEqual({ headers: {}, mode: 'no-cors' })
+    })
+  })
+})

--- a/test/helpers.url-handler.spec.js
+++ b/test/helpers.url-handler.spec.js
@@ -1,95 +1,102 @@
 /* globals describe it expect */
 
-import { format, isAbsolute, combine, concatParams } from '../lib/helpers/url-handler';
-
+import {
+  format,
+  isAbsolute,
+  combine,
+  concatParams,
+} from '../lib/helpers/url-handler'
 
 describe('urlHandler', () => {
   describe('concatParams', () => {
     it('stringify and concats params to the provided URL', () => {
-      const url    = 'https://www.foo.com/bar';
-      const params =  {
+      const url = 'https://www.foo.com/bar'
+      const params = {
         foo: {
           bar: {
-            baz: 'foobarbaz'
-          }
-        }
-      };
+            baz: 'foobarbaz',
+          },
+        },
+      }
 
-      expect(concatParams(url, params))
-      .toBe('https://www.foo.com/bar?foo%5Bbar%5D%5Bbaz%5D=foobarbaz');
-    });
+      expect(concatParams(url, params)).toBe(
+        'https://www.foo.com/bar?foo%5Bbar%5D%5Bbaz%5D=foobarbaz',
+      )
+    })
 
     it('when params are an empty object it returns the same url', () => {
-      const url = 'https://www.foo.com/bar';
-      expect(concatParams(url, {})).toBe(url);
-    });
-  });
+      const url = 'https://www.foo.com/bar'
+      expect(concatParams(url, {})).toBe(url)
+    })
+  })
 
   describe('combine', () => {
     it('creates and return a new URL by combining the specified URLs', () => {
-      const url1  = 'https://www.foo.com/';
-      const path1 = '/bar';
+      const url1 = 'https://www.foo.com/'
+      const path1 = '/bar'
 
-      const url2  = 'https://www.foo.com';
-      const path2 = '/bar';
+      const url2 = 'https://www.foo.com'
+      const path2 = '/bar'
 
-      const url3  = 'https://www.foo.com/';
-      const path3 = 'bar';
+      const url3 = 'https://www.foo.com/'
+      const path3 = 'bar'
 
-      const url4  = 'https://www.foo.com';
-      const path4 = 'bar';
+      const url4 = 'https://www.foo.com'
+      const path4 = 'bar'
 
-      expect(combine(url1, path1)).toEqual('https://www.foo.com/bar');
-      expect(combine(url2, path2)).toEqual('https://www.foo.com/bar');
-      expect(combine(url3, path3)).toEqual('https://www.foo.com/bar');
-      expect(combine(url4, path4)).toEqual('https://www.foo.com/bar');
-    });
-  });
+      expect(combine(url1, path1)).toEqual('https://www.foo.com/bar')
+      expect(combine(url2, path2)).toEqual('https://www.foo.com/bar')
+      expect(combine(url3, path3)).toEqual('https://www.foo.com/bar')
+      expect(combine(url4, path4)).toEqual('https://www.foo.com/bar')
+    })
+  })
 
   describe('isAbsolute', () => {
     it('determines whether the specified URL is absolute', () => {
-      const url1  = 'https://www.foo.com/';
-      const url2  = 'https://www.foo.com/bar';
-      const path1 = '/bar';
-      const path2 = 'bar';
+      const url1 = 'https://www.foo.com/'
+      const url2 = 'https://www.foo.com/bar'
+      const path1 = '/bar'
+      const path2 = 'bar'
 
-      expect(isAbsolute(url1)).toBeTruthy();
-      expect(isAbsolute(url2)).toBeTruthy();
-      expect(isAbsolute(path1)).toBeFalsy();
-      expect(isAbsolute(path2)).toBeFalsy();
-    });
-  });
+      expect(isAbsolute(url1)).toBeTruthy()
+      expect(isAbsolute(url2)).toBeTruthy()
+      expect(isAbsolute(path1)).toBeFalsy()
+      expect(isAbsolute(path2)).toBeFalsy()
+    })
+  })
 
   describe('format', () => {
     it('returns the relative url if base url argument is not defined', () => {
-      const baseUrl     = undefined;
-      const relativeURL = 'https://www.foo.com/bar';
+      const baseUrl = undefined
+      const relativeURL = 'https://www.foo.com/bar'
 
-      expect(format(baseUrl, relativeURL)).toBe(relativeURL);
-    });
+      expect(format(baseUrl, relativeURL)).toBe(relativeURL)
+    })
 
     it('returns the relative url if it is an absolute url', () => {
-      const baseUrl     = 'https://www.foo.com/baz';
-      const relativeURL = 'https://www.foo.com/bar';
+      const baseUrl = 'https://www.foo.com/baz'
+      const relativeURL = 'https://www.foo.com/bar'
 
-      expect(format(baseUrl, relativeURL)).toBe(relativeURL);
-    });
+      expect(format(baseUrl, relativeURL)).toBe(relativeURL)
+    })
 
     it('returns base and realative url combined', () => {
-      const baseUrl     = 'https://www.foo.com/baz/';
-      const relativeURL = '/foo';
+      const baseUrl = 'https://www.foo.com/baz/'
+      const relativeURL = '/foo'
 
-      expect(format(baseUrl, relativeURL)).toBe('https://www.foo.com/baz/foo');
-    });
+      expect(format(baseUrl, relativeURL)).toBe('https://www.foo.com/baz/foo')
+    })
 
     it('returns base, realative url and params combined', () => {
-      const baseUrl     = 'https://www.foo.com/baz/';
-      const relativeURL = '/foo';
-      const params      = {
-        foo: 'bar'
-      };
+      const baseUrl = 'https://www.foo.com/baz/'
+      const relativeURL = '/foo'
+      const params = {
+        foo: 'bar',
+      }
 
-      expect(format(baseUrl, relativeURL, params)).toBe('https://www.foo.com/baz/foo?foo=bar');
-    });
-  });
-});
+      expect(format(baseUrl, relativeURL, params)).toBe(
+        'https://www.foo.com/baz/foo?foo=bar',
+      )
+    })
+  })
+})

--- a/test/middleware.spec.js
+++ b/test/middleware.spec.js
@@ -1,160 +1,152 @@
 /* global describe it expect */
 
-import Middleware from '../lib/middleware';
-
+import Middleware from '../lib/middleware'
 
 describe('Middleware -> middleware', () => {
-  const middleware = new Middleware();
-
   it('initialize before, after and finally middlewares attributes', () => {
-    expect(middleware._before).toEqual([]);
-    expect(middleware._after).toEqual([]);
-    expect(middleware._finally).toEqual([]);
-  });
+    const middleware = new Middleware()
+    expect(middleware._before).toEqual([])
+    expect(middleware._after).toEqual([])
+    expect(middleware._finally).toEqual([])
+  })
 
   describe('before', () => {
     it('adds the middleware to _before and returns its id (Array position)', () => {
-      const middleware = new Middleware();
+      const middleware = new Middleware()
 
-      const id = middleware.before(() => {});
+      const id = middleware.before(() => {})
 
-      expect(middleware._before.length).toEqual(1);
-      expect(id).toEqual(0);
-    });
-  });
+      expect(middleware._before.length).toEqual(1)
+      expect(id).toEqual(0)
+    })
+  })
 
   describe('after', () => {
     it('adds the middleware to _after and returns its id (Array position)', () => {
-      const middleware = new Middleware();
+      const middleware = new Middleware()
 
-      const id = middleware.after(() => {}, () => {});
+      const id = middleware.after(() => {}, () => {})
 
-      expect(middleware._after.length).toEqual(1);
-      expect(id).toEqual(0);
-    });
-  });
+      expect(middleware._after.length).toEqual(1)
+      expect(id).toEqual(0)
+    })
+  })
 
   describe('finally', () => {
     it('adds the middleware to _finally and returns its id (Array position)', () => {
-      const middleware = new Middleware();
+      const middleware = new Middleware()
 
-      const id = middleware.finally(() => {});
+      const id = middleware.finally(() => {})
 
-      expect(middleware._finally.length).toEqual(1);
-      expect(id).toEqual(0);
-    });
-  });
-
+      expect(middleware._finally.length).toEqual(1)
+      expect(id).toEqual(0)
+    })
+  })
 
   describe('resolveBefore', () => {
     it('apply changes to config attribute chaining _before functions', () => {
-      const middleware = new Middleware();
-      const config     = { test: true };
+      const middleware = new Middleware()
+      const config = { test: true }
 
-      middleware.before((config) => {
-        config.foo  = 'bar';
-        return config;
-      });
+      middleware.before((c) => {
+        c.foo = 'bar'
+        return c
+      })
 
-      return middleware.resolveBefore(config)
-      .then((res) => {
+      return middleware.resolveBefore(config).then((res) => {
         expect(res).toEqual({
-          foo : 'bar',
-          test: true
-        });
-      });
-    });
+          foo: 'bar',
+          test: true,
+        })
+      })
+    })
 
     it('apply changes to config attribute chaining _before functions in ascending order', () => {
-      const middleware = new Middleware();
-      const config     = {};
+      const middleware = new Middleware()
+      const config = {}
 
-      middleware.before((config) => {
-        config.order = 0;
-        return config;
-      });
+      middleware.before((c) => {
+        c.order = 0
+        return c
+      })
 
-      middleware.before((config) => {
-        config.order = 1;
-        return config;
-      });
+      middleware.before((c) => {
+        c.order = 1
+        return c
+      })
 
-      middleware.before((config) => {
-        config.order = 2;
-        return config;
-      });
+      middleware.before((c) => {
+        c.order = 2
+        return c
+      })
 
-      return middleware.resolveBefore(config)
-      .then((res) => {
+      return middleware.resolveBefore(config).then((res) => {
         expect(res).toEqual({
-          order: 2
-        });
-      });
-    });
+          order: 2,
+        })
+      })
+    })
 
     it('apply changes to config attribute chaining _before functions mergin data', () => {
-      const middleware = new Middleware();
-      const config     = {};
+      const middleware = new Middleware()
+      const config = {}
 
-      middleware.before((config) => {
-        config.data1 = 'data1';
-        return config;
-      });
+      middleware.before((c) => {
+        c.data1 = 'data1'
+        return c
+      })
 
-      middleware.before((config) => {
-        config.data2 = 'data2';
-        return config;
-      });
+      middleware.before((c) => {
+        c.data2 = 'data2'
+        return c
+      })
 
-      middleware.before((config) => {
-        config.data3 = 'data3';
-        return config;
-      });
+      middleware.before((c) => {
+        c.data3 = 'data3'
+        return c
+      })
 
-      return middleware.resolveBefore(config)
-      .then((res) => {
+      return middleware.resolveBefore(config).then((res) => {
         expect(res).toEqual({
           data1: 'data1',
           data2: 'data2',
-          data3: 'data3'
-        });
-      });
-    });
-  });
+          data3: 'data3',
+        })
+      })
+    })
+  })
 
   describe('resolveAfter', () => {
     it('apply changes to response chaining _after functions (fulfill)', () => {
-      const middleware = new Middleware();
-      const res        = { test: true };
+      const middleware = new Middleware()
+      const res = { test: true }
 
-      middleware.after((res) => {
-        res.foo = 'bar';
-        return res;
-      });
+      middleware.after((r) => {
+        r.foo = 'bar'
+        return r
+      })
 
-      return middleware.resolveAfter(undefined, res)
-      .then((res) => {
-        expect(res).toEqual({
-          foo : 'bar',
-          test: true
-        });
-      });
-    });
+      return middleware.resolveAfter(undefined, res).then((r) => {
+        expect(r).toEqual({
+          foo: 'bar',
+          test: true,
+        })
+      })
+    })
 
     it('apply changes to response chaining _after functions (reject)', () => {
-      const middleware = new Middleware();
-      const err        = new Error('fooTestError');
+      const middleware = new Middleware()
+      const err = new Error('fooTestError')
 
-      middleware.after(undefined, (err) => {
-        err.foo = 'bar';
-        return err;
-      });
+      middleware.after(undefined, (e) => {
+        e.foo = 'bar'
+        return e
+      })
 
-      return middleware.resolveAfter(err)
-      .catch((err) => {
-        expect(err.message).toBe('fooTestError');
-        expect(err.foo).toBe('bar');
-      });
-    });
-  });
-});
+      return middleware.resolveAfter(err).catch((e) => {
+        expect(e.message).toBe('fooTestError')
+        expect(e.foo).toBe('bar')
+      })
+    })
+  })
+})

--- a/test/trae/baseUrl.spec.js
+++ b/test/trae/baseUrl.spec.js
@@ -1,16 +1,16 @@
 /* global describe it expect */
 
-import trae from '../../lib';
+import trae from '../../lib'
 
 describe('trae - baseUrl', () => {
   it('sets the baseUrl or returns if no params are passed', () => {
-    const apiFoo = trae.create();
+    const apiFoo = trae.create()
 
-    expect(apiFoo._baseUrl).toEqual('');
+    expect(apiFoo._baseUrl).toEqual('')
 
-    apiFoo.baseUrl('/api/foo');
+    apiFoo.baseUrl('/api/foo')
 
-    expect(apiFoo._baseUrl).toBe('/api/foo');
-    expect(apiFoo.baseUrl()).toBe('/api/foo');
-  });
-});
+    expect(apiFoo._baseUrl).toBe('/api/foo')
+    expect(apiFoo.baseUrl()).toBe('/api/foo')
+  })
+})

--- a/test/trae/constructor.spec.js
+++ b/test/trae/constructor.spec.js
@@ -1,26 +1,26 @@
 /* global describe it expect */
 
-import trae        from '../../lib';
-import { version } from '../../package.json';
+import trae from '../../lib'
+import { version } from '../../package.json'
 
 describe.only('trae', () => {
   it('exposes the version using the package.json', () => {
-    expect(trae.version).toEqual(version);
-  });
+    expect(trae.version).toEqual(version)
+  })
 
   it('exposes a singleton instance of Trae class with the default config', () => {
-    expect(trae._baseUrl).toEqual('');
-    expect(trae._middleware).toBeDefined();
-    expect(trae._config).toBeDefined();
-  });
+    expect(trae._baseUrl).toEqual('')
+    expect(trae._middleware).toBeDefined()
+    expect(trae._config).toBeDefined()
+  })
 
   it('adds "Content-Type": "application/json" header to the methods with body', () => {
-    expect(trae.defaults().post).toMatchSnapshot();
-    expect(trae.defaults().patch).toMatchSnapshot();
-    expect(trae.defaults().put).toMatchSnapshot();
+    expect(trae.defaults().post).toMatchSnapshot()
+    expect(trae.defaults().patch).toMatchSnapshot()
+    expect(trae.defaults().put).toMatchSnapshot()
 
-    expect(trae.defaults().head).toBe(undefined);
-    expect(trae.defaults().get).toBe(undefined);
-    expect(trae.defaults().delete).toBe(undefined);
-  });
-});
+    expect(trae.defaults().head).toBe(undefined)
+    expect(trae.defaults().get).toBe(undefined)
+    expect(trae.defaults().delete).toBe(undefined)
+  })
+})

--- a/test/trae/create.spec.js
+++ b/test/trae/create.spec.js
@@ -1,68 +1,68 @@
 /* global describe it expect */
-import trae from '../../lib';
+import trae from '../../lib'
 
 describe('trae - create', () => {
   it('returns a new instance of Trae with the provided config as defaults', () => {
-    const apiFoo = trae.create({ baseUrl: '/api/foo' });
-    expect(apiFoo._baseUrl).toBe('/api/foo');
-    expect(apiFoo._middleware).toBeDefined();
-  });
+    const apiFoo = trae.create({ baseUrl: '/api/foo' })
+    expect(apiFoo._baseUrl).toBe('/api/foo')
+    expect(apiFoo._middleware).toBeDefined()
+  })
 
   it('inherits the defaults from the previous instances', () => {
-    trae.baseUrl('/api/foo');
-    trae.defaults({ mode: 'no-cors' });
-    const apiFoo = trae.create();
-    expect(apiFoo._baseUrl).toBe('/api/foo');
-    expect(apiFoo.defaults().mode).toBe('no-cors');
+    trae.baseUrl('/api/foo')
+    trae.defaults({ mode: 'no-cors' })
+    const apiFoo = trae.create()
+    expect(apiFoo._baseUrl).toBe('/api/foo')
+    expect(apiFoo.defaults().mode).toBe('no-cors')
 
-    apiFoo.defaults({ bodyType: 'buffer' });
-    const apiFoo2 = apiFoo.create();
-    expect(apiFoo2._baseUrl).toBe('/api/foo');
-    expect(apiFoo2.defaults().mode).toBe('no-cors');
-    expect(apiFoo2.defaults().bodyType).toBe('buffer');
-  });
+    apiFoo.defaults({ bodyType: 'buffer' })
+    const apiFoo2 = apiFoo.create()
+    expect(apiFoo2._baseUrl).toBe('/api/foo')
+    expect(apiFoo2.defaults().mode).toBe('no-cors')
+    expect(apiFoo2.defaults().bodyType).toBe('buffer')
+  })
 
   it('provided config values override the inherited ones', () => {
-    trae.baseUrl('/api/foo');
-    trae.defaults({ mode: 'cache' });
-    const apiBar = trae.create({ baseUrl: '/api/bar', mode: 'no-cors' });
-    expect(apiBar._baseUrl).toBe('/api/bar');
-    expect(apiBar.defaults().mode).toBe('no-cors');
-  });
+    trae.baseUrl('/api/foo')
+    trae.defaults({ mode: 'cache' })
+    const apiBar = trae.create({ baseUrl: '/api/bar', mode: 'no-cors' })
+    expect(apiBar._baseUrl).toBe('/api/bar')
+    expect(apiBar.defaults().mode).toBe('no-cors')
+  })
 
   it('inherits the middlewares', () => {
     const testTrue = (obj) => {
-      obj.test = true;
-      return obj;
-    };
+      obj.test = true
+      return obj
+    }
     const testFalse = (obj) => {
-      obj.test = false;
-      return obj;
-    };
+      obj.test = false
+      return obj
+    }
 
-    trae.before(testTrue);
-    trae.before(testFalse);
+    trae.before(testTrue)
+    trae.before(testFalse)
 
-    trae.after(testTrue, testTrue);
-    trae.after(testFalse, testFalse);
+    trae.after(testTrue, testTrue)
+    trae.after(testFalse, testFalse)
 
-    trae.finally(() => 'gotta make sure of this');
-    trae.finally(() => 'add this!!!');
+    trae.finally(() => 'gotta make sure of this')
+    trae.finally(() => 'add this!!!')
 
-    const apiTest = trae.create();
+    const apiTest = trae.create()
 
-    expect(apiTest._middleware._before.length).toBe(2);
-    expect(apiTest._middleware._before[0]({})).toEqual({ test: true });
-    expect(apiTest._middleware._before[1]({})).toEqual({ test: false });
+    expect(apiTest._middleware._before.length).toBe(2)
+    expect(apiTest._middleware._before[0]({})).toEqual({ test: true })
+    expect(apiTest._middleware._before[1]({})).toEqual({ test: false })
 
-    expect(apiTest._middleware._after.length).toBe(2);
-    expect(apiTest._middleware._after[0].fulfill({})).toEqual({ test: true });
-    expect(apiTest._middleware._after[0].reject({})).toEqual({ test: true });
-    expect(apiTest._middleware._after[1].fulfill({})).toEqual({ test: false });
-    expect(apiTest._middleware._after[1].reject({})).toEqual({ test: false });
+    expect(apiTest._middleware._after.length).toBe(2)
+    expect(apiTest._middleware._after[0].fulfill({})).toEqual({ test: true })
+    expect(apiTest._middleware._after[0].reject({})).toEqual({ test: true })
+    expect(apiTest._middleware._after[1].fulfill({})).toEqual({ test: false })
+    expect(apiTest._middleware._after[1].reject({})).toEqual({ test: false })
 
-    expect(apiTest._middleware._finally.length).toBe(2);
-    expect(apiTest._middleware._finally[0]({})).toBe('gotta make sure of this');
-    expect(apiTest._middleware._finally[1]({})).toBe('add this!!!');
-  });
-});
+    expect(apiTest._middleware._finally.length).toBe(2)
+    expect(apiTest._middleware._finally[0]({})).toBe('gotta make sure of this')
+    expect(apiTest._middleware._finally[1]({})).toBe('add this!!!')
+  })
+})

--- a/test/trae/defaults.spec.js
+++ b/test/trae/defaults.spec.js
@@ -1,28 +1,28 @@
 /* global describe it expect */
 
-import trae from '../../lib';
+import trae from '../../lib'
 
 describe('trae -> defaults', () => {
   it('returns the current default config when no params are passed', () => {
-    expect(trae.defaults()).toMatchSnapshot();
-  });
+    expect(trae.defaults()).toMatchSnapshot()
+  })
 
   it('sets the default config to be used on all requests for the instance', () => {
-    trae.defaults({ mode: 'no-cors', credentials: 'same-origin' });
-    expect(trae.defaults()).toMatchSnapshot();
-  });
+    trae.defaults({ mode: 'no-cors', credentials: 'same-origin' })
+    expect(trae.defaults()).toMatchSnapshot()
+  })
 
   it('adds the baseUrl to trae._baseUrl but does not add it to the defaults', () => {
-    const apiFoo = trae.create();
-    apiFoo.defaults({ baseUrl: '/api/foo' });
-    expect(apiFoo._baseUrl).toBe('/api/foo');
-    expect(apiFoo._config.get().baseUrl).not.toBeDefined();
-  });
+    const apiFoo = trae.create()
+    apiFoo.defaults({ baseUrl: '/api/foo' })
+    expect(apiFoo._baseUrl).toBe('/api/foo')
+    expect(apiFoo._config.get().baseUrl).not.toBeDefined()
+  })
 
   it('adds the baseUrl to trae._baseUrl and add it to the default response', () => {
-    const apiFoo = trae.create();
-    apiFoo.defaults({ baseUrl: '/api/foo' });
-    expect(apiFoo._baseUrl).toBe('/api/foo');
-    expect(apiFoo.defaults().baseUrl).toBeDefined();
-  });
-});
+    const apiFoo = trae.create()
+    apiFoo.defaults({ baseUrl: '/api/foo' })
+    expect(apiFoo._baseUrl).toBe('/api/foo')
+    expect(apiFoo.defaults().baseUrl).toBeDefined()
+  })
+})

--- a/test/trae/delete.spec.js
+++ b/test/trae/delete.spec.js
@@ -1,42 +1,44 @@
 /* global describe it expect afterEach */
 
-import fetchMock from 'fetch-mock';
-import trae      from '../../lib';
+import fetchMock from 'fetch-mock'
+import trae from '../../lib'
 
 afterEach(() => {
-  fetchMock.restore();
-});
+  fetchMock.restore()
+})
 
-const TEST_URL = 'http://localhost:8080/api';
+const TEST_URL = 'http://localhost:8080/api'
 
 describe('trae -> delete', () => {
   it('makes a DELETE request to baseURL + path', () => {
-    const url = `${TEST_URL}/foo`;
+    const url = `${TEST_URL}/foo`
 
-    fetchMock.mock(url, {
-      status : 200,
-      body   : 'Deleted!',
-      headers: {
-        'Content-Type': 'application/text'
-      }
-    }, {
-      method: 'delete'
-    });
+    fetchMock.mock(
+      url,
+      {
+        status: 200,
+        body: 'Deleted!',
+        headers: {
+          'Content-Type': 'application/text',
+        },
+      },
+      {
+        method: 'delete',
+      },
+    )
 
-    const testTrae = trae.create();
+    const testTrae = trae.create()
 
     testTrae.before((c) => {
-      expect(c.headers).toEqual({});
-      return c;
-    });
+      expect(c.headers).toEqual({})
+      return c
+    })
 
-
-    return testTrae.delete(url)
-    .then((res) => {
-      expect(res).toMatchSnapshot();
-      expect(fetchMock.called(url)).toBeTruthy();
-      expect(fetchMock.lastUrl()).toBe(url);
-      expect(fetchMock.lastOptions().method).toBe('DELETE');
-    });
-  });
-});
+    return testTrae.delete(url).then((res) => {
+      expect(res).toMatchSnapshot()
+      expect(fetchMock.called(url)).toBeTruthy()
+      expect(fetchMock.lastUrl()).toBe(url)
+      expect(fetchMock.lastOptions().method).toBe('DELETE')
+    })
+  })
+})

--- a/test/trae/get.spec.js
+++ b/test/trae/get.spec.js
@@ -1,142 +1,144 @@
 /* global describe it expect afterEach */
 
-import fetchMock from 'fetch-mock';
-import trae      from '../../lib';
+import fetchMock from 'fetch-mock'
+import trae from '../../lib'
 
 afterEach(() => {
-  fetchMock.restore();
-});
+  fetchMock.restore()
+})
 
-const TEST_URL = 'http://localhost:8080/api';
+const TEST_URL = 'http://localhost:8080/api'
 
 describe('trae -> get', () => {
   it('does not have headers set by defualt', (next) => {
-    const url = `${TEST_URL}/foo`;
+    const url = `${TEST_URL}/foo`
 
     fetchMock.mock(url, {
-      status : 200,
+      status: 200,
       headers: {
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
       },
       body: {
-        foo: 'bar'
-      }
-    });
+        foo: 'bar',
+      },
+    })
 
-    const testTrae = trae.create();
+    const testTrae = trae.create()
 
     testTrae.before((c) => {
-      expect(c.headers).toEqual({});
-      next();
-      return c;
-    });
+      expect(c.headers).toEqual({})
+      next()
+      return c
+    })
 
-
-    return testTrae.get(url);
-  });
+    return testTrae.get(url)
+  })
 
   it('makes a GET request to baseURL + path', () => {
-    const url = `${TEST_URL}/foo`;
+    const url = `${TEST_URL}/foo`
 
     fetchMock.mock(url, {
-      status : 200,
+      status: 200,
       headers: {
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
       },
       body: {
-        foo: 'bar'
-      }
-    });
+        foo: 'bar',
+      },
+    })
 
-    return trae.get(url)
-    .then((res) => {
-      expect(res).toMatchSnapshot();
-      expect(fetchMock.called(url)).toBeTruthy();
-      expect(fetchMock.lastUrl()).toBe(url);
-      expect(fetchMock.lastOptions().method).toBe('GET');
-    });
-  });
+    return trae.get(url).then((res) => {
+      expect(res).toMatchSnapshot()
+      expect(fetchMock.called(url)).toBeTruthy()
+      expect(fetchMock.lastUrl()).toBe(url)
+      expect(fetchMock.lastOptions().method).toBe('GET')
+    })
+  })
 
   it('makes a GET request with raw bodyType and get the body without being parsed', () => {
-    const url = `${TEST_URL}/foo`;
+    const url = `${TEST_URL}/foo`
 
     fetchMock.mock(url, {
-      status : 200,
+      status: 200,
       headers: {
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
       },
       body: {
-        foo: 'bar'
-      }
-    });
+        foo: 'bar',
+      },
+    })
 
-    return trae.get(url, { bodyType: 'raw' })
-    .then((res) => {
-      expect(res).toMatchSnapshot();
-      expect(fetchMock.called(url)).toBeTruthy();
-      expect(fetchMock.lastUrl()).toBe(url);
-      expect(fetchMock.lastOptions().method).toBe('GET');
-    });
-  });
+    return trae.get(url, { bodyType: 'raw' }).then((res) => {
+      expect(res).toMatchSnapshot()
+      expect(fetchMock.called(url)).toBeTruthy()
+      expect(fetchMock.lastUrl()).toBe(url)
+      expect(fetchMock.lastOptions().method).toBe('GET')
+    })
+  })
 
   describe('get -> params', () => {
-
     afterEach(() => {
-      fetchMock.restore();
-    });
+      fetchMock.restore()
+    })
 
     it('makes a GET request to baseURL + path using params', () => {
-      const url = `${TEST_URL}/foo`;
-      const qs  = '?foo=bar&key=123&token=12345lkjhpor837';
+      const url = `${TEST_URL}/foo`
+      const qs = '?foo=bar&key=123&token=12345lkjhpor837'
 
       fetchMock.mock(url + qs, {
-        status : 200,
+        status: 200,
         headers: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
         },
         body: {
-          foo: 'bar'
-        }
-      });
+          foo: 'bar',
+        },
+      })
 
-      return trae.get(url, { params: {
-        foo  : 'bar',
-        key  : 123,
-        token: '12345lkjhpor837'
-      } })
-      .then((res) => {
-        expect(res).toMatchSnapshot();
-        expect(fetchMock.called(url + qs)).toBeTruthy();
-        expect(fetchMock.lastUrl()).toBe(url + qs);
-        expect(fetchMock.lastOptions().method).toBe('GET');
-      });
-    });
+      return trae
+        .get(url, {
+          params: {
+            foo: 'bar',
+            key: 123,
+            token: '12345lkjhpor837',
+          },
+        })
+        .then((res) => {
+          expect(res).toMatchSnapshot()
+          expect(fetchMock.called(url + qs)).toBeTruthy()
+          expect(fetchMock.lastUrl()).toBe(url + qs)
+          expect(fetchMock.lastOptions().method).toBe('GET')
+        })
+    })
 
     it('makes a GET request to baseURL + path using a nested object as params', () => {
-      const url = `${TEST_URL}/foo`;
-      const qs  = '?a%5Bb%5D=c';
+      const url = `${TEST_URL}/foo`
+      const qs = '?a%5Bb%5D=c'
 
       fetchMock.mock(url + qs, {
-        status : 200,
+        status: 200,
         headers: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
         },
         body: {
-          foo: 'bar'
-        }
-      });
+          foo: 'bar',
+        },
+      })
 
-      return trae.get(url, { params: {
-        a: {
-          b: 'c'
-        }
-      } })
-      .then((res) => {
-        expect(res).toMatchSnapshot();
-        expect(fetchMock.called(url + qs)).toBeTruthy();
-        expect(fetchMock.lastUrl()).toBe(url + qs);
-        expect(fetchMock.lastOptions().method).toBe('GET');
-      });
-    });
-  });
-});
+      return trae
+        .get(url, {
+          params: {
+            a: {
+              b: 'c',
+            },
+          },
+        })
+        .then((res) => {
+          expect(res).toMatchSnapshot()
+          expect(fetchMock.called(url + qs)).toBeTruthy()
+          expect(fetchMock.lastUrl()).toBe(url + qs)
+          expect(fetchMock.lastOptions().method).toBe('GET')
+        })
+    })
+  })
+})

--- a/test/trae/head.spec.js
+++ b/test/trae/head.spec.js
@@ -1,38 +1,40 @@
 /* global describe it expect afterEach */
 
-import fetchMock from 'fetch-mock';
-import trae      from '../../lib';
+import fetchMock from 'fetch-mock'
+import trae from '../../lib'
 
 afterEach(() => {
-  fetchMock.restore();
-});
+  fetchMock.restore()
+})
 
-const TEST_URL = 'http://localhost:8080/api';
+const TEST_URL = 'http://localhost:8080/api'
 
 describe('trae -> head', () => {
   it('makes a HEAD request to baseURL + path', () => {
-    const url = `${TEST_URL}/foo`;
+    const url = `${TEST_URL}/foo`
 
-    fetchMock.mock(url, {
-      status: 200
-    }, {
-      method: 'head'
-    });
+    fetchMock.mock(
+      url,
+      {
+        status: 200,
+      },
+      {
+        method: 'head',
+      },
+    )
 
-    const testTrae = trae.create();
+    const testTrae = trae.create()
 
     testTrae.before((c) => {
-      expect(c.headers).toEqual({});
-      return c;
-    });
+      expect(c.headers).toEqual({})
+      return c
+    })
 
-
-    return testTrae.head(url)
-    .then((res) => {
-      expect(res).toMatchSnapshot();
-      expect(fetchMock.called(url)).toBeTruthy();
-      expect(fetchMock.lastUrl()).toBe(url);
-      expect(fetchMock.lastOptions().method).toBe('HEAD');
-    });
-  });
-});
+    return testTrae.head(url).then((res) => {
+      expect(res).toMatchSnapshot()
+      expect(fetchMock.called(url)).toBeTruthy()
+      expect(fetchMock.lastUrl()).toBe(url)
+      expect(fetchMock.lastOptions().method).toBe('HEAD')
+    })
+  })
+})

--- a/test/trae/middleware.spec.js
+++ b/test/trae/middleware.spec.js
@@ -1,166 +1,160 @@
 /* global describe it expect afterEach */
 
-import fetchMock from 'fetch-mock';
-import trae      from '../../lib';
+import fetchMock from 'fetch-mock'
+import trae from '../../lib'
 
 afterEach(() => {
-  fetchMock.restore();
-});
+  fetchMock.restore()
+})
 
-const TEST_URL = 'http://localhost:8080/api';
+const TEST_URL = 'http://localhost:8080/api'
 
 describe('trae - middleware', () => {
-
   it('sets the middlewares', () => {
-    const apiFoo    = trae.create();
-    const identity  = response => response;
-    const rejection = err => Promise.reject(err);
-    const noop      = () => {};
+    const apiFoo = trae.create()
+    const identity = (response) => response
+    const rejection = (err) => Promise.reject(err)
+    const noop = () => {}
 
+    apiFoo.before(identity)
+    apiFoo.after(identity, rejection)
+    apiFoo.finally(noop)
 
-    apiFoo.before(identity);
-    apiFoo.after(identity, rejection);
-    apiFoo.finally(noop);
-
-    expect(apiFoo._middleware._before[0]).toBe(identity);
-    expect(apiFoo._middleware._finally[0]).toBe(noop);
+    expect(apiFoo._middleware._before[0]).toBe(identity)
+    expect(apiFoo._middleware._finally[0]).toBe(noop)
     expect(apiFoo._middleware._after[0]).toEqual({
       fulfill: identity,
-      reject : rejection
-    });
-  });
+      reject: rejection,
+    })
+  })
 
   describe('before', () => {
     it('runs the before middlewares', () => {
-      const apiFoo     = trae.create();
-      const url        = `${TEST_URL}/foo`;
-      let configRunned = false;
+      const apiFoo = trae.create()
+      const url = `${TEST_URL}/foo`
+      let configRunned = false
 
       fetchMock.mock(url, {
-        status : 200,
+        status: 200,
         headers: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
         },
         body: {
-          foo: 'bar'
-        }
-      });
+          foo: 'bar',
+        },
+      })
 
       apiFoo.before((config) => {
-        config.headers.Authorization = '12345Foo';
-        configRunned = true;
-        return config;
-      });
+        config.headers.Authorization = '12345Foo'
+        configRunned = true
+        return config
+      })
 
-      return apiFoo.get(url)
-      .then((res) => {
-        expect(configRunned).toBe(true);
-        expect(res).toMatchSnapshot();
-        expect(fetchMock.called(url)).toBeTruthy();
-        expect(fetchMock.lastUrl()).toBe(url);
-        expect(fetchMock.lastOptions().method).toBe('GET');
-        expect(fetchMock.lastOptions().headers.Authorization).toBe('12345Foo');
-      });
-    });
-  });
+      return apiFoo.get(url).then((res) => {
+        expect(configRunned).toBe(true)
+        expect(res).toMatchSnapshot()
+        expect(fetchMock.called(url)).toBeTruthy()
+        expect(fetchMock.lastUrl()).toBe(url)
+        expect(fetchMock.lastOptions().method).toBe('GET')
+        expect(fetchMock.lastOptions().headers.Authorization).toBe('12345Foo')
+      })
+    })
+  })
 
   describe('after', () => {
     it('runs the fulfill after middlewares', () => {
-      const apiFoo    = trae.create();
-      const url       = `${TEST_URL}/foo`;
-      let afterRunned = false;
+      const apiFoo = trae.create()
+      const url = `${TEST_URL}/foo`
+      let afterRunned = false
 
       fetchMock.mock(url, {
-        status : 200,
+        status: 200,
         headers: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
         },
         body: {
-          foo: 'bar'
-        }
-      });
+          foo: 'bar',
+        },
+      })
 
       apiFoo.after((res) => {
-        res.data.test = true;
-        afterRunned   = true;
-        return res;
-      });
+        res.data.test = true
+        afterRunned = true
+        return res
+      })
 
-      return apiFoo.get(url)
-      .then((res) => {
-        expect(res.data.test).toBe(true);
-        expect(afterRunned).toBe(true);
-        expect(res).toMatchSnapshot();
-        expect(fetchMock.called(url)).toBeTruthy();
-        expect(fetchMock.lastUrl()).toBe(url);
-        expect(fetchMock.lastOptions().method).toBe('GET');
-      });
-    });
+      return apiFoo.get(url).then((res) => {
+        expect(res.data.test).toBe(true)
+        expect(afterRunned).toBe(true)
+        expect(res).toMatchSnapshot()
+        expect(fetchMock.called(url)).toBeTruthy()
+        expect(fetchMock.lastUrl()).toBe(url)
+        expect(fetchMock.lastOptions().method).toBe('GET')
+      })
+    })
 
     it('runs the reject after middlewares', () => {
-      const apiFoo = trae.create();
-      const url    = `${TEST_URL}/foo`;
+      const apiFoo = trae.create()
+      const url = `${TEST_URL}/foo`
 
       fetchMock.mock(url, {
         status: 500,
         body: { message: 'Error in the server' },
         headers: {
-          'Content-Type': 'application/json'
-        }
-      });
+          'Content-Type': 'application/json',
+        },
+      })
 
-      const fulfill = res => Promise.resolve(res);
+      const fulfill = (res) => Promise.resolve(res)
 
       const reject = (err) => {
-        err.test = true;
-        return Promise.reject(err);
-      };
+        err.test = true
+        return Promise.reject(err)
+      }
 
-      apiFoo.after(fulfill, reject);
+      apiFoo.after(fulfill, reject)
 
-      return apiFoo.get(url)
-      .catch((err) => {
-        expect(err.status).toBe(500);
-        expect(err.test).toBe(true);
-        expect(err.data).toEqual({ message: 'Error in the server' });
-        expect(err).toMatchSnapshot();
-        expect(fetchMock.called(url)).toBeTruthy();
-        expect(fetchMock.lastUrl()).toBe(url);
-        expect(fetchMock.lastOptions().method).toBe('GET');
-      });
-    });
-  });
+      return apiFoo.get(url).catch((err) => {
+        expect(err.status).toBe(500)
+        expect(err.test).toBe(true)
+        expect(err.data).toEqual({ message: 'Error in the server' })
+        expect(err).toMatchSnapshot()
+        expect(fetchMock.called(url)).toBeTruthy()
+        expect(fetchMock.lastUrl()).toBe(url)
+        expect(fetchMock.lastOptions().method).toBe('GET')
+      })
+    })
+  })
 
   describe('finally', () => {
     it('runs the finally middlewares', () => {
-      const apiFoo      = trae.create();
-      const url         = `${TEST_URL}/foo`;
-      let finallyRunned = false;
+      const apiFoo = trae.create()
+      const url = `${TEST_URL}/foo`
+      let finallyRunned = false
       const mockConfig = {
-        status : 200,
+        status: 200,
         headers: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
         },
         body: {
-          foo: 'bar'
-        }
-      };
-      fetchMock.mock(url, mockConfig);
+          foo: 'bar',
+        },
+      }
+      fetchMock.mock(url, mockConfig)
 
       apiFoo.finally((conf, passedUrl) => {
-        expect(conf.mySpecialConfig).toBe('unicorn');
-        expect(passedUrl).toBe(url);
-        finallyRunned = true;
-      });
+        expect(conf.mySpecialConfig).toBe('unicorn')
+        expect(passedUrl).toBe(url)
+        finallyRunned = true
+      })
 
-      return apiFoo.get(url, { mySpecialConfig: 'unicorn' })
-      .then((res) => {
-        expect(finallyRunned).toBe(true);
-        expect(res).toMatchSnapshot();
-        expect(fetchMock.called(url)).toBeTruthy();
-        expect(fetchMock.lastUrl()).toBe(url);
-        expect(fetchMock.lastOptions().method).toBe('GET');
-      });
-    });
-  });
-});
+      return apiFoo.get(url, { mySpecialConfig: 'unicorn' }).then((res) => {
+        expect(finallyRunned).toBe(true)
+        expect(res).toMatchSnapshot()
+        expect(fetchMock.called(url)).toBeTruthy()
+        expect(fetchMock.lastUrl()).toBe(url)
+        expect(fetchMock.lastOptions().method).toBe('GET')
+      })
+    })
+  })
+})

--- a/test/trae/patch.spec.js
+++ b/test/trae/patch.spec.js
@@ -1,44 +1,46 @@
 /* global describe it expect afterEach */
 
-import fetchMock from 'fetch-mock';
-import trae      from '../../lib';
+import fetchMock from 'fetch-mock'
+import trae from '../../lib'
 
 afterEach(() => {
-  fetchMock.restore();
-});
+  fetchMock.restore()
+})
 
-const TEST_URL = 'http://localhost:8080/api';
+const TEST_URL = 'http://localhost:8080/api'
 
 describe('trae -> patch', () => {
   it('makes a PATCH request to baseURL + path', () => {
-    const url = `${TEST_URL}/foo`;
+    const url = `${TEST_URL}/foo`
 
-    fetchMock.mock(url, {
-      status : 200,
-      body   : {
-        foo: 'bar'
+    fetchMock.mock(
+      url,
+      {
+        status: 200,
+        body: {
+          foo: 'bar',
+        },
+        headers: {
+          'Content-Type': 'application/json',
+        },
       },
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    }, {
-      method: 'patch'
-    });
+      {
+        method: 'patch',
+      },
+    )
 
-    const testTrae = trae.create();
+    const testTrae = trae.create()
 
     testTrae.before((c) => {
-      expect(c.headers).toMatchSnapshot();
-      return c;
-    });
+      expect(c.headers).toMatchSnapshot()
+      return c
+    })
 
-
-    return testTrae.patch(url, { foo: 'bar' })
-    .then((res) => {
-      expect(res).toMatchSnapshot();
-      expect(fetchMock.called(url)).toBeTruthy();
-      expect(fetchMock.lastUrl()).toBe(url);
-      expect(fetchMock.lastOptions().method).toBe('PATCH');
-    });
-  });
-});
+    return testTrae.patch(url, { foo: 'bar' }).then((res) => {
+      expect(res).toMatchSnapshot()
+      expect(fetchMock.called(url)).toBeTruthy()
+      expect(fetchMock.lastUrl()).toBe(url)
+      expect(fetchMock.lastOptions().method).toBe('PATCH')
+    })
+  })
+})

--- a/test/trae/post.spec.js
+++ b/test/trae/post.spec.js
@@ -1,115 +1,130 @@
 /* global describe it expect afterEach */
 
-import fetchMock from 'fetch-mock';
-import trae      from '../../lib';
+import fetchMock from 'fetch-mock'
+import trae from '../../lib'
 
 afterEach(() => {
-  fetchMock.restore();
-});
+  fetchMock.restore()
+})
 
-const TEST_URL = 'http://localhost:8080/api';
+const TEST_URL = 'http://localhost:8080/api'
 
 describe('trae -> post', () => {
   it('makes a POST request to baseURL + path', () => {
-    const url = `${TEST_URL}/foo`;
+    const url = `${TEST_URL}/foo`
 
-    fetchMock.mock(url, {
-      status: 200,
-      body  : {
-        foo: 'bar'
+    fetchMock.mock(
+      url,
+      {
+        status: 200,
+        body: {
+          foo: 'bar',
+        },
+        headers: {
+          'Content-Type': 'application/json',
+        },
       },
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    }, {
-      method: 'post'
-    });
+      {
+        method: 'post',
+      },
+    )
 
-    const testTrae = trae.create();
+    const testTrae = trae.create()
 
     testTrae.before((c) => {
-      expect(c.headers).toMatchSnapshot();
-      return c;
-    });
+      expect(c.headers).toMatchSnapshot()
+      return c
+    })
 
-
-    return testTrae.post(url, { foo: 'bar' })
-    .then((res) => {
-      expect(res).toMatchSnapshot();
-      expect(fetchMock.called(url)).toBeTruthy();
-      expect(fetchMock.lastUrl()).toBe(url);
-      expect(fetchMock.lastOptions().method).toBe('POST');
-    });
-  });
+    return testTrae.post(url, { foo: 'bar' }).then((res) => {
+      expect(res).toMatchSnapshot()
+      expect(fetchMock.called(url)).toBeTruthy()
+      expect(fetchMock.lastUrl()).toBe(url)
+      expect(fetchMock.lastOptions().method).toBe('POST')
+    })
+  })
 
   describe('post -> params', () => {
-
     afterEach(() => {
-      fetchMock.restore();
-    });
+      fetchMock.restore()
+    })
 
     it('makes a POST request to baseURL + path using params', () => {
-      const url = `${TEST_URL}/foo`;
-      const qs  = '?foo=bar&key=123&token=12345lkjhpor837';
+      const url = `${TEST_URL}/foo`
+      const qs = '?foo=bar&key=123&token=12345lkjhpor837'
 
-      fetchMock.mock(url + qs, {
-        status : 200,
-        headers: {
-          'Content-Type': 'application/json'
+      fetchMock.mock(
+        url + qs,
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: {
+            foo: 'bar',
+          },
         },
-        body: {
-          foo: 'bar'
-        }
-      }, {
-        method: 'post'
-      });
+        {
+          method: 'post',
+        },
+      )
 
-      return trae.post(url, {
-        sarasa: 'request body'
-      }, {
-        params: {
-          foo  : 'bar',
-          key  : 123,
-          token: '12345lkjhpor837'
-        }
-      })
-      .then((res) => {
-        expect(res).toMatchSnapshot();
-        expect(fetchMock.called(url + qs)).toBeTruthy();
-        expect(fetchMock.lastUrl()).toBe(url + qs);
-        expect(fetchMock.lastOptions().method).toBe('POST');
-      });
-    });
+      return trae
+        .post(
+          url,
+          {
+            sarasa: 'request body',
+          },
+          {
+            params: {
+              foo: 'bar',
+              key: 123,
+              token: '12345lkjhpor837',
+            },
+          },
+        )
+        .then((res) => {
+          expect(res).toMatchSnapshot()
+          expect(fetchMock.called(url + qs)).toBeTruthy()
+          expect(fetchMock.lastUrl()).toBe(url + qs)
+          expect(fetchMock.lastOptions().method).toBe('POST')
+        })
+    })
 
     it('makes a POST request to baseURL + path using a nested object as params', () => {
-      const url = `${TEST_URL}/foo`;
-      const qs  = '?a%5Bb%5D=c';
+      const url = `${TEST_URL}/foo`
+      const qs = '?a%5Bb%5D=c'
 
       fetchMock.mock(url + qs, {
-        status : 200,
+        status: 200,
         headers: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
         },
         body: {
-          foo: 'bar'
-        }
-      });
-
-      return trae.post(url, {
-        sarasa: 'request body'
-      }, {
-        params: {
-          a: {
-            b: 'c'
-          }
-        }
+          foo: 'bar',
+        },
       })
-      .then((res) => {
-        expect(res).toMatchSnapshot();
-        expect(fetchMock.called(url + qs)).toBeTruthy();
-        expect(fetchMock.lastUrl()).toBe(url + qs);
-        expect(fetchMock.lastOptions().method).toBe('POST');
-      });
-    });
-  });
-});
+
+      return trae
+        .post(
+          url,
+          {
+            sarasa: 'request body',
+          },
+          {
+            params: {
+              a: {
+                b: 'c',
+              },
+            },
+          },
+        )
+        .then((res) => {
+          expect(res).toMatchSnapshot()
+          expect(fetchMock.called(url + qs)).toBeTruthy()
+          expect(fetchMock.lastUrl()).toBe(url + qs)
+          expect(fetchMock.lastOptions().method).toBe('POST')
+        })
+    })
+  })
+})

--- a/test/trae/put.spec.js
+++ b/test/trae/put.spec.js
@@ -1,44 +1,46 @@
 /* global describe it expect afterEach */
 
-import fetchMock from 'fetch-mock';
-import trae      from '../../lib';
+import fetchMock from 'fetch-mock'
+import trae from '../../lib'
 
 afterEach(() => {
-  fetchMock.restore();
-});
+  fetchMock.restore()
+})
 
-const TEST_URL = 'http://localhost:8080/api';
+const TEST_URL = 'http://localhost:8080/api'
 
 describe('trae -> put', () => {
   it('makes a PUT request to baseURL + path', () => {
-    const url = `${TEST_URL}/foo`;
+    const url = `${TEST_URL}/foo`
 
-    fetchMock.mock(url, {
-      status : 200,
-      body   : {
-        foo: 'bar'
+    fetchMock.mock(
+      url,
+      {
+        status: 200,
+        body: {
+          foo: 'bar',
+        },
+        headers: {
+          'Content-Type': 'application/json',
+        },
       },
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    }, {
-      method: 'put'
-    });
+      {
+        method: 'put',
+      },
+    )
 
-    const testTrae = trae.create();
+    const testTrae = trae.create()
 
     testTrae.before((c) => {
-      expect(c.headers).toMatchSnapshot();
-      return c;
-    });
+      expect(c.headers).toMatchSnapshot()
+      return c
+    })
 
-
-    return testTrae.put(url, { foo: 'bar' })
-    .then((res) => {
-      expect(res).toMatchSnapshot();
-      expect(fetchMock.called(url)).toBeTruthy();
-      expect(fetchMock.lastUrl()).toBe(url);
-      expect(fetchMock.lastOptions().method).toBe('PUT');
-    });
-  });
-});
+    return testTrae.put(url, { foo: 'bar' }).then((res) => {
+      expect(res).toMatchSnapshot()
+      expect(fetchMock.called(url)).toBeTruthy()
+      expect(fetchMock.lastUrl()).toBe(url)
+      expect(fetchMock.lastOptions().method).toBe('PUT')
+    })
+  })
+})

--- a/test/trae/request.spec.js
+++ b/test/trae/request.spec.js
@@ -1,195 +1,224 @@
 /* global describe it expect afterEach */
 
-import fetchMock from 'fetch-mock';
-import trae      from '../../lib';
+import fetchMock from 'fetch-mock'
+import trae from '../../lib'
 
 afterEach(() => {
-  fetchMock.restore();
-});
+  fetchMock.restore()
+})
 
-const TEST_URL = 'http://localhost:8080/api';
+const TEST_URL = 'http://localhost:8080/api'
 
 describe('trae -> request', () => {
-
   afterEach(() => {
-    fetchMock.restore();
-  });
+    fetchMock.restore()
+  })
 
   it('makes a GET request to baseURL + path using the request method', () => {
-    const url = `${TEST_URL}/foo`;
+    const url = `${TEST_URL}/foo`
 
-    fetchMock.mock(`${url}?foo=sar&bar=test`, {
-      status : 200,
-      body   : {
-        foo: 'bar'
+    fetchMock.mock(
+      `${url}?foo=sar&bar=test`,
+      {
+        status: 200,
+        body: {
+          foo: 'bar',
+        },
+        headers: {
+          'Content-Type': 'application/json',
+        },
       },
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    }, {
-      method: 'get'
-    });
+      {
+        method: 'get',
+      },
+    )
 
-    return trae.request({
-      url,
-      method: 'get',
-      params: {
-        foo: 'sar',
-        bar: 'test'
-      }
-    })
-    .then((res) => {
-      expect(res).toMatchSnapshot();
-      expect(fetchMock.called(`${url}?foo=sar&bar=test`)).toBeTruthy();
-      expect(fetchMock.lastUrl()).toBe(`${url}?foo=sar&bar=test`);
-      expect(fetchMock.lastOptions().method).toBe('GET');
-    });
-  });
+    return trae
+      .request({
+        url,
+        method: 'get',
+        params: {
+          foo: 'sar',
+          bar: 'test',
+        },
+      })
+      .then((res) => {
+        expect(res).toMatchSnapshot()
+        expect(fetchMock.called(`${url}?foo=sar&bar=test`)).toBeTruthy()
+        expect(fetchMock.lastUrl()).toBe(`${url}?foo=sar&bar=test`)
+        expect(fetchMock.lastOptions().method).toBe('GET')
+      })
+  })
 
   it('makes a POST request to baseURL + path using the request method', () => {
-    const url = `${TEST_URL}/foo`;
+    const url = `${TEST_URL}/foo`
 
-    fetchMock.mock(url, {
-      status : 200,
-      body   : {
-        foo: 'bar'
-      },
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    }, {
-      method: 'post'
-    });
-
-    return trae.request({
+    fetchMock.mock(
       url,
-      method: 'post',
-      body  : {
-        foo: 'baz'
-      }
-    })
-    .then((res) => {
-      expect(res).toMatchSnapshot();
-      expect(fetchMock.called(url)).toBeTruthy();
-      expect(fetchMock.lastUrl()).toBe(url);
-      expect(fetchMock.lastOptions().method).toBe('POST');
-    });
-  });
+      {
+        status: 200,
+        body: {
+          foo: 'bar',
+        },
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+      {
+        method: 'post',
+      },
+    )
+
+    return trae
+      .request({
+        url,
+        method: 'post',
+        body: {
+          foo: 'baz',
+        },
+      })
+      .then((res) => {
+        expect(res).toMatchSnapshot()
+        expect(fetchMock.called(url)).toBeTruthy()
+        expect(fetchMock.lastUrl()).toBe(url)
+        expect(fetchMock.lastOptions().method).toBe('POST')
+      })
+  })
 
   it('makes a PUT request to baseURL + path using the request method', () => {
-    const url = `${TEST_URL}/foo`;
+    const url = `${TEST_URL}/foo`
 
-    fetchMock.mock(url, {
-      status : 200,
-      body   : {
-        foo: 'bar'
-      },
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    }, {
-      method: 'put'
-    });
-
-    return trae.request({
+    fetchMock.mock(
       url,
-      method: 'put',
-      body  : {
-        foo: 'bar'
-      }
-    })
-    .then((res) => {
-      expect(res).toMatchSnapshot();
-      expect(fetchMock.called(url)).toBeTruthy();
-      expect(fetchMock.lastUrl()).toBe(url);
-      expect(fetchMock.lastOptions().method).toBe('PUT');
-    });
-  });
+      {
+        status: 200,
+        body: {
+          foo: 'bar',
+        },
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+      {
+        method: 'put',
+      },
+    )
+
+    return trae
+      .request({
+        url,
+        method: 'put',
+        body: {
+          foo: 'bar',
+        },
+      })
+      .then((res) => {
+        expect(res).toMatchSnapshot()
+        expect(fetchMock.called(url)).toBeTruthy()
+        expect(fetchMock.lastUrl()).toBe(url)
+        expect(fetchMock.lastOptions().method).toBe('PUT')
+      })
+  })
 
   it('makes a PATCH request to baseURL + path using the request method', () => {
-    const url = `${TEST_URL}/foo`;
+    const url = `${TEST_URL}/foo`
 
-    fetchMock.mock(url, {
-      status : 200,
-      body   : {
-        foo: 'bar'
-      },
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    }, {
-      method: 'patch'
-    });
-
-    return trae.request({
+    fetchMock.mock(
       url,
-      method: 'patch',
-      body  : {
-        foo: 'bar'
-      }
-    })
-    .then((res) => {
-      expect(res).toMatchSnapshot();
-      expect(fetchMock.called(url)).toBeTruthy();
-      expect(fetchMock.lastUrl()).toBe(url);
-      expect(fetchMock.lastOptions().method).toBe('PATCH');
-    });
-  });
+      {
+        status: 200,
+        body: {
+          foo: 'bar',
+        },
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+      {
+        method: 'patch',
+      },
+    )
+
+    return trae
+      .request({
+        url,
+        method: 'patch',
+        body: {
+          foo: 'bar',
+        },
+      })
+      .then((res) => {
+        expect(res).toMatchSnapshot()
+        expect(fetchMock.called(url)).toBeTruthy()
+        expect(fetchMock.lastUrl()).toBe(url)
+        expect(fetchMock.lastOptions().method).toBe('PATCH')
+      })
+  })
 
   it('makes a DELETE request to baseURL + path using the request method', () => {
-    const url = `${TEST_URL}/foo`;
+    const url = `${TEST_URL}/foo`
 
-    fetchMock.mock(url, {
-      status : 200,
-      body   : {
-        foo: 'bar'
-      },
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    }, {
-      method: 'delete'
-    });
-
-    return trae.request({
+    fetchMock.mock(
       url,
-      method: 'delete',
-      body  : {
-        baz: 'foo'
-      }
-    })
-    .then((res) => {
-      expect(res).toMatchSnapshot();
-      expect(fetchMock.called(url)).toBeTruthy();
-      expect(fetchMock.lastUrl()).toBe(url);
-      expect(fetchMock.lastOptions().method).toBe('DELETE');
-    });
-  });
+      {
+        status: 200,
+        body: {
+          foo: 'bar',
+        },
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+      {
+        method: 'delete',
+      },
+    )
+
+    return trae
+      .request({
+        url,
+        method: 'delete',
+        body: {
+          baz: 'foo',
+        },
+      })
+      .then((res) => {
+        expect(res).toMatchSnapshot()
+        expect(fetchMock.called(url)).toBeTruthy()
+        expect(fetchMock.lastUrl()).toBe(url)
+        expect(fetchMock.lastOptions().method).toBe('DELETE')
+      })
+  })
 
   it('makes a HEAD request to baseURL + path using the request method', () => {
-    const url = `${TEST_URL}/foo`;
+    const url = `${TEST_URL}/foo`
 
-    fetchMock.mock(url, {
-      status : 200,
-      body   : {
-        foo: 'bar'
-      },
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    }, {
-      method: 'head'
-    });
-
-    return trae.request({
+    fetchMock.mock(
       url,
-      method: 'head'
-    })
-    .then((res) => {
-      expect(res).toMatchSnapshot();
-      expect(fetchMock.called(url)).toBeTruthy();
-      expect(fetchMock.lastUrl()).toBe(url);
-      expect(fetchMock.lastOptions().method).toBe('HEAD');
-    });
-  });
-});
+      {
+        status: 200,
+        body: {
+          foo: 'bar',
+        },
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+      {
+        method: 'head',
+      },
+    )
+
+    return trae
+      .request({
+        url,
+        method: 'head',
+      })
+      .then((res) => {
+        expect(res).toMatchSnapshot()
+        expect(fetchMock.called(url)).toBeTruthy()
+        expect(fetchMock.lastUrl()).toBe(url)
+        expect(fetchMock.lastOptions().method).toBe('HEAD')
+      })
+  })
+})

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -1,7 +1,6 @@
 /* globals describe it expect */
 
-import { skip } from '../lib/utils';
-
+import { skip } from '../lib/utils'
 
 describe('utils', () => {
   describe('skip', () => {
@@ -10,26 +9,26 @@ describe('utils', () => {
         foo: 'bar',
         baz: [1, 2, 3],
         nested: {
-          foo: 'bar'
-        }
-      };
+          foo: 'bar',
+        },
+      }
       const expected = {
         baz: [1, 2, 3],
         nested: {
-          foo: 'bar'
-        }
-      };
-      const actual = skip(obj, ['foo']);
-      expect(actual).toEqual(expected);
-    });
+          foo: 'bar',
+        },
+      }
+      const actual = skip(obj, ['foo'])
+      expect(actual).toEqual(expected)
+    })
 
     it('returns the same object if the keys are not on the object', () => {
       const obj = {
-        foo: 'bar'
-      };
+        foo: 'bar',
+      }
 
-      const actual = skip(obj, ['baz']);
-      expect(actual).toEqual(obj);
-    });
-  });
-});
+      const actual = skip(obj, ['baz'])
+      expect(actual).toEqual(obj)
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -2052,6 +2052,12 @@ eslint-config-airbnb@^14.1.0:
   dependencies:
     eslint-config-airbnb-base "^11.1.0"
 
+eslint-config-prettier@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-2.9.0.tgz#5ecd65174d486c22dff389fe036febf502d468a3"
+  dependencies:
+    get-stdin "^5.0.1"
+
 eslint-import-resolver-node@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz#58f15fb839b8d0576ca980413476aab2472db66a"
@@ -2626,6 +2632,10 @@ get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
 
+get-stdin@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
+
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
@@ -2955,7 +2965,7 @@ idb-wrapper@^1.5.0:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/idb-wrapper/-/idb-wrapper-1.7.2.tgz#8251afd5e77fe95568b1c16152eb44b396767ea2"
 
-ignore@^3.2.0, ignore@^3.3.3:
+ignore@^3.2.0, ignore@^3.3.3, ignore@^3.3.7:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.7.tgz#612289bfb3c220e186a58118618d5be8c1bab021"
 
@@ -4395,6 +4405,10 @@ mkdirp@0.5.1, mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
+mri@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.0.tgz#5c0a3f29c8ccffbbb1ec941dcec09d71fa32f36a"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -4958,6 +4972,10 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
+prettier@^1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.11.1.tgz#61e43fc4cd44e68f2b0dfc2c38cd4bb0fccdcc75"
+
 pretty-format@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-22.4.3.tgz#f873d780839a9c02e9664c8a082e9ee79eaac16f"
@@ -4971,6 +4989,16 @@ pretty-ms@^3.1.0:
   dependencies:
     parse-ms "^1.0.0"
     plur "^2.1.2"
+
+pretty-quick@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/pretty-quick/-/pretty-quick-1.4.1.tgz#9d41f778d2d4d940ec603d1293a0998e84c4722c"
+  dependencies:
+    chalk "^2.3.0"
+    execa "^0.8.0"
+    find-up "^2.1.0"
+    ignore "^3.3.7"
+    mri "^1.1.0"
 
 private@^0.1.6, private@^0.1.7, private@~0.1.5:
   version "0.1.8"


### PR DESCRIPTION
This PR adds `prettier` to format code, removes `eslint` format related rules (and some other ones that were not used) and adds `pretty-quick` to run prettier on changed files and files staged to commit.