### PR TITLE
Types improvements

### DIFF
--- a/lib/create-request-body.ts
+++ b/lib/create-request-body.ts
@@ -1,29 +1,10 @@
 import { TraeSettings } from '../src/types';
-import { isValidBody, isHeaders } from './guards';
+import { isValidBody } from './guards';
 
 function isJSON({ headers }: TraeSettings) {
-  if (!headers) {
-    return false;
-  }
+  const header = new Headers(headers).get('Content-Type') || '';
 
-  if (isHeaders(headers)) {
-    const headerValue = headers.get('Content-Type') || '';
-    return headerValue.toLowerCase().includes('application/json');
-  }
-
-  if (Array.isArray(headers)) {
-    return headers.some(
-      ([name, value]) =>
-        name.toLowerCase() === 'content-type' &&
-        value.toLowerCase().includes('application/json'),
-    );
-  }
-
-  return Object.keys(headers).some(
-    (name: string) =>
-      name.toLowerCase().includes('content-type') &&
-      headers[name].toLowerCase().includes('application/json'),
-  );
+  return header.toLowerCase().includes('application/json');
 }
 
 function createRequestBody(content: unknown, config: TraeSettings) {

--- a/lib/create-request-body.ts
+++ b/lib/create-request-body.ts
@@ -1,66 +1,41 @@
 import { TraeSettings } from '../src/types';
-import { isFormData } from './create-response';
+import { isValidBody, isHeaders } from './guards';
 
 function isJSON({ headers }: TraeSettings) {
   if (!headers) {
     return false;
   }
 
-  if (Array.isArray(headers)) {
-    const result = headers.find(
-      ([headerName]) => headerName.toLowerCase() === 'content-type',
-    );
-    const [, headerValue] = result || ['', ''];
-
-    return headerValue.toLowerCase().includes('application/json');
-  }
-
-  if (headers instanceof Headers) {
+  if (isHeaders(headers)) {
     const headerValue = headers.get('Content-Type') || '';
-
     return headerValue.toLowerCase().includes('application/json');
   }
 
-  const key =
-    Object.keys(headers).find((header: string) =>
-      header.toLowerCase().includes('content-type'),
-    ) || '';
-
-  const headerValue = headers[key] || '';
-
-  return headerValue.toLowerCase().includes('application/json');
-}
-
-// TODO: this function is inconplete
-function isValidBody(content: unknown): content is BodyInit {
-  if (typeof content === 'string') {
-    return true;
-  }
-  if (typeof ArrayBuffer !== 'undefined' && content instanceof ArrayBuffer) {
-    return true;
-  }
-  if (typeof Blob !== 'undefined' && content instanceof Blob) {
-    return true;
-  }
-  if (isFormData(content)) {
-    return true;
-  }
-  if (
-    typeof ReadableStream !== 'undefined' &&
-    content instanceof ReadableStream
-  ) {
-    return true;
+  if (Array.isArray(headers)) {
+    return headers.some(
+      ([name, value]) =>
+        name.toLowerCase() === 'content-type' &&
+        value.toLowerCase().includes('application/json'),
+    );
   }
 
-  return false;
+  return Object.keys(headers).some(
+    (name: string) =>
+      name.toLowerCase().includes('content-type') &&
+      headers[name].toLowerCase().includes('application/json'),
+  );
 }
 
 function createRequestBody(content: unknown, config: TraeSettings) {
-  if (isValidBody(content)) {
-    return isJSON(config) ? JSON.stringify(content) : content;
+  if (isJSON(config)) {
+    return JSON.stringify(content);
   }
 
-  // TODO do not throw here
+  if (isValidBody(content)) {
+    return content;
+  }
+
+  // TODO do not throw here, return a promise instead
   // TODO what does fetch do when body is invalid?
   throw new Error(`Invalid body type: ${typeof content}`);
 }

--- a/lib/create-request-body.ts
+++ b/lib/create-request-body.ts
@@ -1,18 +1,68 @@
 import { TraeSettings } from '../src/types';
+import { isFormData } from './create-response';
 
-function isJSON(config: TraeSettings) {
-  const headers = config.headers;
-  // @ts-ignore
-  const key = Object.keys(headers).find(
-    // @ts-ignore
-    (header: any) => header.toLowerCase() === 'content-type',
-  );
-  // @ts-ignore
-  return key && headers[key].toLowerCase() === 'application/json';
+function isJSON({ headers }: TraeSettings) {
+  if (!headers) {
+    return false;
+  }
+
+  if (Array.isArray(headers)) {
+    const result = headers.find(
+      ([headerName]) => headerName.toLowerCase() === 'content-type',
+    );
+    const [, headerValue] = result || ['', ''];
+
+    return headerValue.toLowerCase().includes('application/json');
+  }
+
+  if (headers instanceof Headers) {
+    const headerValue = headers.get('Content-Type') || '';
+
+    return headerValue.toLowerCase().includes('application/json');
+  }
+
+  const key =
+    Object.keys(headers).find((header: string) =>
+      header.toLowerCase().includes('content-type'),
+    ) || '';
+
+  const headerValue = headers[key] || '';
+
+  return headerValue.toLowerCase().includes('application/json');
 }
 
-function createRequestBody(content: any, config: TraeSettings) {
-  return isJSON(config) ? JSON.stringify(content) : content;
+// TODO: this function is inconplete
+function isValidBody(content: unknown): content is BodyInit {
+  if (typeof content === 'string') {
+    return true;
+  }
+  if (typeof ArrayBuffer !== 'undefined' && content instanceof ArrayBuffer) {
+    return true;
+  }
+  if (typeof Blob !== 'undefined' && content instanceof Blob) {
+    return true;
+  }
+  if (isFormData(content)) {
+    return true;
+  }
+  if (
+    typeof ReadableStream !== 'undefined' &&
+    content instanceof ReadableStream
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+function createRequestBody(content: unknown, config: TraeSettings) {
+  if (isValidBody(content)) {
+    return isJSON(config) ? JSON.stringify(content) : content;
+  }
+
+  // TODO do not throw here
+  // TODO what does fetch do when body is invalid?
+  throw new Error(`Invalid body type: ${typeof content}`);
 }
 
 export default createRequestBody;

--- a/lib/create-response.ts
+++ b/lib/create-response.ts
@@ -3,7 +3,7 @@ import { BodyType, TraeSettings } from '../src/types';
 const isValidReader = (reader: string): reader is BodyType =>
   ['arrayBuffer', 'blob', 'formData', 'json', 'text', 'raw'].includes(reader);
 
-function isFormData(body: unknown): body is FormData {
+export function isFormData(body: unknown): body is FormData {
   return typeof FormData !== 'undefined' && body instanceof FormData;
 }
 
@@ -12,6 +12,7 @@ interface TraeResponseErrorArgs {
   config: TraeSettings;
   response: Response;
 }
+
 class TraeResponseError extends Error {
   config: TraeSettings;
   response: Response;
@@ -23,7 +24,7 @@ class TraeResponseError extends Error {
   }
 }
 
-function deriveReader(response: Response, config: TraeSettings) {
+function deriveReader(response: Response, config: TraeSettings): BodyType {
   const { bodyType } = config;
   const { headers, body } = response;
 
@@ -54,7 +55,21 @@ function deriveReader(response: Response, config: TraeSettings) {
   return 'text';
 }
 
-function parseResponse(response: Response, config: TraeSettings) {
+interface TraeResponse {
+  status: number;
+  statusText: string;
+  data: unknown;
+}
+
+// TODO: we should return one type or the other depending on the reader type so
+// the user doesn't get the union always but the right type according to the
+// config they have
+type ParsedResponse = Promise<Response | TraeResponse>;
+
+function parseResponse(
+  response: Response,
+  config: TraeSettings,
+): ParsedResponse {
   const reader = deriveReader(response, config);
 
   return reader === 'raw'
@@ -66,21 +81,19 @@ function parseResponse(response: Response, config: TraeSettings) {
       }));
 }
 
-export default function createResponse(
-  response: Response,
-  config: TraeSettings,
-) {
-    if (response.ok) {
-      return parseResponse(response, config);
-    }
-
-    const error = new TraeResponseError({
-      message: response.statusText,
-      config,
-      response,
-    });
-
-    // TODO: Why isn't the parsed response part of the object we reject with?
-    // @ts-ignore
-    return parseResponse(response, config).then(() => Promise.reject(error));
+const createResponse = (config: TraeSettings) => (response: Response) => {
+  if (response.ok) {
+    return parseResponse(response, config);
   }
+
+  const error = new TraeResponseError({
+    message: response.statusText,
+    config,
+    response,
+  });
+
+  // TODO: Why isn't the parsed response part of the object we reject with?
+  return parseResponse(response, config).then(() => Promise.reject(error));
+};
+
+export default createResponse;

--- a/lib/create-response.ts
+++ b/lib/create-response.ts
@@ -1,11 +1,5 @@
 import { BodyType, TraeSettings } from '../src/types';
-
-const isValidReader = (reader: string): reader is BodyType =>
-  ['arrayBuffer', 'blob', 'formData', 'json', 'text', 'raw'].includes(reader);
-
-export function isFormData(body: unknown): body is FormData {
-  return typeof FormData !== 'undefined' && body instanceof FormData;
-}
+import { isFormData, isBlob, isArrayBuffer, isValidReader } from './guards';
 
 interface TraeResponseErrorArgs {
   message: string;
@@ -32,21 +26,24 @@ function deriveReader(response: Response, config: TraeSettings): BodyType {
     return bodyType;
   }
 
-  const contentType = headers.get('Content-Type');
+  const contentType = headers.get('Content-Type') || '';
 
-  if (contentType === 'application/json') {
+  if (contentType.toLowerCase().includes('application/json')) {
     return 'json';
   }
 
-  if (contentType === 'multipart/form-data' || isFormData(body)) {
+  if (
+    contentType.toLowerCase().includes('multipart/form-data') ||
+    isFormData(body)
+  ) {
     return 'formData';
   }
 
-  if (body instanceof ArrayBuffer) {
+  if (isArrayBuffer(body)) {
     return 'arrayBuffer';
   }
 
-  if (body instanceof Blob) {
+  if (isBlob(body)) {
     // TODO: Investigate edge cases
     //       https://stackoverflow.com/a/55271454/3377073
     return 'blob';

--- a/lib/guards.ts
+++ b/lib/guards.ts
@@ -4,10 +4,6 @@ export function isFormData(body: unknown): body is FormData {
   return typeof FormData !== 'undefined' && body instanceof FormData;
 }
 
-export function isHeaders(headers: unknown): headers is Headers {
-  return typeof Headers !== 'undefined' && headers instanceof Headers;
-}
-
 export function isArrayBuffer(value: unknown): value is ArrayBuffer {
   return typeof ArrayBuffer !== 'undefined' && value instanceof ArrayBuffer;
 }

--- a/lib/guards.ts
+++ b/lib/guards.ts
@@ -1,0 +1,55 @@
+import { BodyType } from '../src/types';
+
+export function isFormData(body: unknown): body is FormData {
+  return typeof FormData !== 'undefined' && body instanceof FormData;
+}
+
+export function isHeaders(headers: unknown): headers is Headers {
+  return typeof Headers !== 'undefined' && headers instanceof Headers;
+}
+
+export function isArrayBuffer(value: unknown): value is ArrayBuffer {
+  return typeof ArrayBuffer !== 'undefined' && value instanceof ArrayBuffer;
+}
+
+export function isBlob(value: unknown): value is Blob {
+  return typeof Blob !== 'undefined' && value instanceof Blob;
+}
+
+export function isReadableStream(value: unknown): value is ReadableStream {
+  return (
+    typeof ReadableStream !== 'undefined' && value instanceof ReadableStream
+  );
+}
+
+export function isURLSearchParams(value: unknown): value is URLSearchParams {
+  return (
+    typeof URLSearchParams !== 'undefined' && value instanceof URLSearchParams
+  );
+}
+
+export function isValidReader(reader: string): reader is BodyType {
+  return ['arrayBuffer', 'blob', 'formData', 'json', 'text', 'raw'].includes(
+    reader,
+  );
+}
+
+// TODO: this function is inconplete
+export function isValidBody(content: unknown): content is BodyInit {
+  if (typeof content === 'string') {
+    return true;
+  }
+  if (isArrayBuffer(content)) {
+    return true;
+  }
+  if (isBlob(content)) {
+    return true;
+  }
+  if (isFormData(content)) {
+    return true;
+  }
+  if (isReadableStream(content)) {
+    return true;
+  }
+  return isURLSearchParams(content);
+}

--- a/src/trae.ts
+++ b/src/trae.ts
@@ -36,17 +36,17 @@ function createTrae(providedConf?: Partial<TraeSettings>) {
     return createTrae(merge(config, instanceConfig));
   }
 
-  function get(endpoint: string, requestConfig: RequestInit = {}) {
+  function get(endpoint: string, requestConfig?: RequestInit) {
     const settings: TraeSettings = merge({}, config, requestConfig);
     return request(endpoint, { ...settings, method: 'GET' });
   }
 
-  function remove(endpoint: string, requestConfig: RequestInit = {}) {
+  function remove(endpoint: string, requestConfig?: RequestInit) {
     const settings: TraeSettings = merge({}, config, requestConfig);
     return request(endpoint, { ...settings, method: 'DELETE' });
   }
 
-  function head(endpoint: string, requestConfig: RequestInit = {}) {
+  function head(endpoint: string, requestConfig?: RequestInit) {
     const settings: TraeSettings = merge({}, config, requestConfig);
     return request(endpoint, { ...settings, method: 'HEAD' });
   }

--- a/src/trae.ts
+++ b/src/trae.ts
@@ -1,6 +1,6 @@
 import merge from 'lodash/merge';
 
-import createRequestBody from '../lib/create-request-body'
+import createRequestBody from '../lib/create-request-body';
 import createResponse from '../lib/create-response';
 import { format as formatUrl } from '../lib/url';
 import { TraeSettings, InstanceConfig } from './types';
@@ -10,12 +10,14 @@ const defaults: RequestInit = {
 };
 
 function createTrae(providedConf?: Partial<TraeSettings>) {
-  const config: TraeSettings = Object.freeze(merge(defaults, {
-    before: (conf: RequestInit) => conf,
-    onResolve: (item: unknown) => Promise.resolve(item),
-    onReject: (err: unknown) => Promise.reject(err),
-    ...providedConf,
-  }));
+  const config: TraeSettings = Object.freeze(
+    merge(defaults, {
+      before: (conf: RequestInit) => conf,
+      onResolve: (item: unknown) => Promise.resolve(item),
+      onReject: (err: unknown) => Promise.reject(err),
+      ...providedConf,
+    }),
+  );
 
   function request(endpoint: string, settings: TraeSettings) {
     // TODO: We should extract some attributes to avoid exposing unnecessary
@@ -25,7 +27,7 @@ function createTrae(providedConf?: Partial<TraeSettings>) {
     const url = formatUrl(settings.url, endpoint, settings.params);
 
     return fetch(url, config.before(settings))
-      .then((res: any) => createResponse(res, settings))
+      .then(createResponse(settings))
       .then(config.onResolve)
       .catch(config.onReject);
   }
@@ -35,48 +37,57 @@ function createTrae(providedConf?: Partial<TraeSettings>) {
   }
 
   function get(endpoint: string, requestConfig: RequestInit = {}) {
-    const settings: TraeSettings = merge({}, config, requestConfig); 
+    const settings: TraeSettings = merge({}, config, requestConfig);
     return request(endpoint, { ...settings, method: 'GET' });
   }
 
   function remove(endpoint: string, requestConfig: RequestInit = {}) {
-    const settings: TraeSettings = merge({}, config, requestConfig); 
+    const settings: TraeSettings = merge({}, config, requestConfig);
     return request(endpoint, { ...settings, method: 'DELETE' });
   }
 
   function head(endpoint: string, requestConfig: RequestInit = {}) {
-    const settings: TraeSettings = merge({}, config, requestConfig); 
+    const settings: TraeSettings = merge({}, config, requestConfig);
     return request(endpoint, { ...settings, method: 'HEAD' });
   }
 
   function post(
     endpoint: string,
-    data: any = {},
-    requestConfig: RequestInit = {},
+    body: unknown = {},
+    requestConfig?: RequestInit,
   ) {
-    const settings: TraeSettings = merge({}, config, requestConfig); 
-    const body = createRequestBody(data, settings);
-    return request(endpoint, { ...settings, method: 'POST', body });
+    const settings: TraeSettings = merge({}, config, requestConfig);
+    return request(endpoint, {
+      ...settings,
+      method: 'POST',
+      body: createRequestBody(body, settings),
+    });
   }
 
   function put(
     endpoint: string,
-    data: any = {},
-    requestConfig: RequestInit = {},
+    body: unknown = {},
+    requestConfig?: RequestInit,
   ) {
     const settings: TraeSettings = merge({}, config, requestConfig);
-    const body = createRequestBody(data, settings);
-    return request(endpoint, { ...settings, method: 'PUT', body });
+    return request(endpoint, {
+      ...settings,
+      method: 'PUT',
+      body: createRequestBody(body, settings),
+    });
   }
 
   function patch(
     endpoint: string,
-    data: any = {},
-    requestConfig: RequestInit = {},
+    body: unknown = {},
+    requestConfig?: RequestInit,
   ) {
     const settings: TraeSettings = merge({}, config, requestConfig);
-    const body = createRequestBody(data, settings);
-    return request(endpoint, { ...settings, method: 'PATCH', body });
+    return request(endpoint, {
+      ...settings,
+      method: 'PATCH',
+      body: createRequestBody(body, settings),
+    });
   }
 
   return {

--- a/test/trae/post.spec.ts
+++ b/test/trae/post.spec.ts
@@ -5,6 +5,8 @@ import nock from 'nock';
 import fetch from 'node-fetch';
 import trae from '../../src';
 
+global.Headers = fetch.Headers;
+
 const TEST_URL = 'http://localhost:8080';
 
 describe('trae -> post', () => {


### PR DESCRIPTION
This PR adds some fixes on types

- Remote `@ts-ignore`: `isJSON` now covers all the cases `Headers` type can be.
- `createRequestBody` only returns `BodyInit` type (this is what fetch expects)
- Added `lib/guards` for all runtime type checks
- Change type of `body` in requests: `any -> unknown`
- Remove requests config default argument, keep it optional
- Update `createResponse` signature to take one argument at a time:

```diff
- .then((res: any) => createResponse(res, settings))
+ .then(createResponse(settings))
```