### PR TITLE
Replace dependencies to improve bundle size

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -799,12 +799,6 @@
         "pretty-format": "^25.1.0"
       }
     },
-    "@types/lodash": {
-      "version": "4.14.149",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
-      "integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
-      "dev": true
-    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -846,11 +840,14 @@
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
       "dev": true
     },
-    "@types/qs": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.0.tgz",
-      "integrity": "sha512-c4zji5CjWv1tJxIZkz1oUtGcdOlsH3aza28Nqmm+uNDWBRHoMsjooBEN4czZp1V3iXPihE/VRUOBqg+4Xq0W4g==",
-      "dev": true
+    "@types/query-string": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@types/query-string/-/query-string-6.3.0.tgz",
+      "integrity": "sha512-yuIv/WRffRzL7cBW+sla4HwBZrEXRNf1MKQ5SklPEadth+BKbDxiVG8A3iISN5B3yC4EeSCzMZP8llHTcUhOzQ==",
+      "dev": true,
+      "requires": {
+        "query-string": "*"
+      }
     },
     "@types/resolve": {
       "version": "0.0.8",
@@ -1343,98 +1340,6 @@
         }
       }
     },
-    "babel-helper-call-delegate": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-      "dev": true,
-      "requires": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-define-map": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
-      "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
-      "dev": true,
-      "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
-      }
-    },
-    "babel-helper-function-name": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-      "dev": true,
-      "requires": {
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-get-function-arity": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-hoist-variables": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-optimise-call-expression": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
-      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-helper-regex": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
-      "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
-      }
-    },
-    "babel-helper-replace-supers": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
-      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-      "dev": true,
-      "requires": {
-        "babel-helper-optimise-call-expression": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
     "babel-helpers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
@@ -1445,72 +1350,10 @@
         "babel-template": "^6.24.1"
       }
     },
-    "babel-jest": {
-      "version": "25.1.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-25.1.0.tgz",
-      "integrity": "sha512-tz0VxUhhOE2y+g8R2oFrO/2VtVjA1lkJeavlhExuRBg3LdNJY9gwQ+Vcvqt9+cqy71MCTJhewvTB7Qtnnr9SWg==",
-      "dev": true,
-      "requires": {
-        "@jest/transform": "^25.1.0",
-        "@jest/types": "^25.1.0",
-        "@types/babel__core": "^7.1.0",
-        "babel-plugin-istanbul": "^6.0.0",
-        "babel-preset-jest": "^25.1.0",
-        "chalk": "^3.0.0",
-        "slash": "^3.0.0"
-      }
-    },
-    "babel-loader": {
-      "version": "8.0.6",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.0.6.tgz",
-      "integrity": "sha512-4BmWKtBOBm13uoUwd08UwjZlaw3O9GWf456R9j+5YykFZ6LUIjIKLc0zEZf+hauxPOJs96C8k6FvYD09vWzhYw==",
-      "dev": true,
-      "requires": {
-        "find-cache-dir": "^2.0.0",
-        "loader-utils": "^1.0.2",
-        "mkdirp": "^0.5.1",
-        "pify": "^4.0.1"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        }
-      }
-    },
     "babel-messages": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-check-es2015-constants": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-external-helpers": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz",
-      "integrity": "sha1-IoX0iwK9Xe3oUXXK+MYuhq3M76E=",
       "dev": true,
       "requires": {
         "babel-runtime": "^6.22.0"
@@ -1538,123 +1381,6 @@
         "@types/babel__traverse": "^7.0.6"
       }
     },
-    "babel-plugin-transform-es2015-arrow-functions": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
-      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-block-scoped-functions": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
-      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-block-scoping": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
-      "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.26.0",
-        "babel-template": "^6.26.0",
-        "babel-traverse": "^6.26.0",
-        "babel-types": "^6.26.0",
-        "lodash": "^4.17.4"
-      }
-    },
-    "babel-plugin-transform-es2015-classes": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
-      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-      "dev": true,
-      "requires": {
-        "babel-helper-define-map": "^6.24.1",
-        "babel-helper-function-name": "^6.24.1",
-        "babel-helper-optimise-call-expression": "^6.24.1",
-        "babel-helper-replace-supers": "^6.24.1",
-        "babel-messages": "^6.23.0",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-computed-properties": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
-      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-destructuring": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-duplicate-keys": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
-      "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-for-of": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
-      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-function-name": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
-      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-      "dev": true,
-      "requires": {
-        "babel-helper-function-name": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-literals": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
-      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-amd": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
-      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
-      }
-    },
     "babel-plugin-transform-es2015-modules-commonjs": {
       "version": "6.26.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
@@ -1667,120 +1393,6 @@
         "babel-types": "^6.26.0"
       }
     },
-    "babel-plugin-transform-es2015-modules-systemjs": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
-      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-      "dev": true,
-      "requires": {
-        "babel-helper-hoist-variables": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-umd": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
-      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-object-super": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
-      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-      "dev": true,
-      "requires": {
-        "babel-helper-replace-supers": "^6.24.1",
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-parameters": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-      "dev": true,
-      "requires": {
-        "babel-helper-call-delegate": "^6.24.1",
-        "babel-helper-get-function-arity": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-template": "^6.24.1",
-        "babel-traverse": "^6.24.1",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-shorthand-properties": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
-      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-spread": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-sticky-regex": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-      "dev": true,
-      "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "babel-types": "^6.24.1"
-      }
-    },
-    "babel-plugin-transform-es2015-template-literals": {
-      "version": "6.22.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
-      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-typeof-symbol": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
-      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.22.0"
-      }
-    },
-    "babel-plugin-transform-es2015-unicode-regex": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-      "dev": true,
-      "requires": {
-        "babel-helper-regex": "^6.24.1",
-        "babel-runtime": "^6.22.0",
-        "regexpu-core": "^2.0.0"
-      }
-    },
-    "babel-plugin-transform-regenerator": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
-      "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
-      "dev": true,
-      "requires": {
-        "regenerator-transform": "^0.10.0"
-      }
-    },
     "babel-plugin-transform-strict-mode": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
@@ -1789,49 +1401,6 @@
       "requires": {
         "babel-runtime": "^6.22.0",
         "babel-types": "^6.24.1"
-      }
-    },
-    "babel-preset-es2015": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
-      "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-check-es2015-constants": "^6.22.0",
-        "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
-        "babel-plugin-transform-es2015-classes": "^6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "^6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "^6.22.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
-        "babel-plugin-transform-es2015-for-of": "^6.22.0",
-        "babel-plugin-transform-es2015-function-name": "^6.24.1",
-        "babel-plugin-transform-es2015-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-        "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
-        "babel-plugin-transform-es2015-object-super": "^6.24.1",
-        "babel-plugin-transform-es2015-parameters": "^6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
-        "babel-plugin-transform-es2015-spread": "^6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "^6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
-        "babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
-        "babel-plugin-transform-regenerator": "^6.24.1"
-      }
-    },
-    "babel-preset-es2015-rollup": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-es2015-rollup/-/babel-preset-es2015-rollup-3.0.0.tgz",
-      "integrity": "sha1-hUtj7N4u6YysQOiC9nv88YWx8ko=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-external-helpers": "^6.18.0",
-        "babel-preset-es2015": "^6.3.13",
-        "require-relative": "^0.8.7"
       }
     },
     "babel-preset-jest": {
@@ -3041,8 +2610,7 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "decompress-response": {
       "version": "3.3.0",
@@ -4298,72 +3866,6 @@
         "parseurl": "~1.3.3",
         "statuses": "~1.5.0",
         "unpipe": "~1.0.0"
-      }
-    },
-    "find-cache-dir": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
-      "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
-      "dev": true,
-      "requires": {
-        "commondir": "^1.0.1",
-        "make-dir": "^2.0.0",
-        "pkg-dir": "^3.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "make-dir": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-          "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
-          "dev": true,
-          "requires": {
-            "pify": "^4.0.1",
-            "semver": "^5.6.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-          "dev": true
-        },
-        "pkg-dir": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-          "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-          "dev": true,
-          "requires": {
-            "find-up": "^3.0.0"
-          }
-        }
       }
     },
     "find-up": {
@@ -7062,7 +6564,8 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -9341,7 +8844,18 @@
     "qs": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
-      "integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA=="
+      "integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA==",
+      "dev": true
+    },
+    "query-string": {
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.11.1.tgz",
+      "integrity": "sha512-1ZvJOUl8ifkkBxu2ByVM/8GijMIPx+cef7u3yroO3Ogm4DOdZcF5dcrWTIlSHe3Pg/mtlt6/eFjObDfJureZZA==",
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      }
     },
     "querystring": {
       "version": "0.2.0",
@@ -9488,28 +9002,11 @@
         "strip-indent": "^1.0.1"
       }
     },
-    "regenerate": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
-      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
-      "dev": true
-    },
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
       "dev": true
-    },
-    "regenerator-transform": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
-      "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "^6.18.0",
-        "babel-types": "^6.19.0",
-        "private": "^0.1.6"
-      }
     },
     "regex-not": {
       "version": "1.0.2",
@@ -9537,17 +9034,6 @@
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
     },
-    "regexpu-core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-      "dev": true,
-      "requires": {
-        "regenerate": "^1.2.1",
-        "regjsgen": "^0.2.0",
-        "regjsparser": "^0.1.4"
-      }
-    },
     "registry-auth-token": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.1.1.tgz",
@@ -9564,29 +9050,6 @@
       "dev": true,
       "requires": {
         "rc": "^1.2.8"
-      }
-    },
-    "regjsgen": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
-      "dev": true
-    },
-    "regjsparser": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-      "dev": true,
-      "requires": {
-        "jsesc": "~0.5.0"
-      },
-      "dependencies": {
-        "jsesc": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
-          "dev": true
-        }
       }
     },
     "remark": {
@@ -9779,12 +9242,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
-    },
-    "require-relative": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
-      "integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
       "dev": true
     },
     "requires-port": {
@@ -10533,6 +9990,11 @@
         "through": "2"
       }
     },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -10609,6 +10071,11 @@
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
+    },
+    "strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-length": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "build": "rollup --config",
     "docs": "http-server ./docs -o",
     "test": "jest --coverage --verbose",
-    "test:w": "jest --watch --verbose",
+    "test:w": "jest --watch",
     "check-cover": "open coverage/lcov-report/index.html",
     "format": "prettier --write '**/*.js'",
     "check-bundle": "open coverage/bundle-statistics.html",
@@ -44,16 +44,14 @@
     "release": "np"
   },
   "dependencies": {
-    "lodash": "^4.17.15",
-    "qs": "^6.9.1"
+    "query-string": "^6.11.1"
   },
   "devDependencies": {
     "@types/body-parser": "^1.19.0",
     "@types/connect": "^3.4.33",
     "@types/jest": "^25.1.1",
-    "@types/lodash": "^4.14.149",
     "@types/node-fetch": "^2.5.5",
-    "@types/qs": "^6.9.0",
+    "@types/query-string": "^6.3.0",
     "body-parser": "^1.19.0",
     "chimi": "^0.2.2",
     "connect": "^3.7.0",

--- a/src/trae.ts
+++ b/src/trae.ts
@@ -1,9 +1,8 @@
-import merge from 'lodash/merge';
-
 import createRequestBody from './create-request-body';
 import createResponse from './create-response';
 import { format as formatUrl } from './url';
 import { TraeSettings, InstanceConfig } from './types';
+import { merge } from './utils'
 
 const defaults: RequestInit = {
   headers: { 'Content-Type': 'application/json' },
@@ -11,7 +10,7 @@ const defaults: RequestInit = {
 
 function createTrae(providedConf?: Partial<TraeSettings>) {
   const config: TraeSettings = Object.freeze(
-    merge({}, defaults, {
+    merge(defaults, {
       before: (conf: RequestInit) => conf,
       onResolve: (item: unknown) => Promise.resolve(item),
       onReject: (err: unknown) => Promise.reject(err),
@@ -33,21 +32,21 @@ function createTrae(providedConf?: Partial<TraeSettings>) {
   }
 
   function create(instanceConfig: InstanceConfig) {
-    return createTrae(merge({}, config, instanceConfig));
+    return createTrae(merge(config, instanceConfig));
   }
 
   function get(endpoint: string, requestConfig?: RequestInit) {
-    const settings: TraeSettings = merge({}, config, requestConfig);
+    const settings: TraeSettings = merge(config, requestConfig);
     return request(endpoint, { ...settings, method: 'GET' });
   }
 
   function remove(endpoint: string, requestConfig?: RequestInit) {
-    const settings: TraeSettings = merge({}, config, requestConfig);
+    const settings: TraeSettings = merge(config, requestConfig);
     return request(endpoint, { ...settings, method: 'DELETE' });
   }
 
   function head(endpoint: string, requestConfig?: RequestInit) {
-    const settings: TraeSettings = merge({}, config, requestConfig);
+    const settings: TraeSettings = merge(config, requestConfig);
     return request(endpoint, { ...settings, method: 'HEAD' });
   }
 
@@ -56,7 +55,7 @@ function createTrae(providedConf?: Partial<TraeSettings>) {
     body: unknown = {},
     requestConfig?: RequestInit,
   ) {
-    const settings: TraeSettings = merge({}, config, requestConfig);
+    const settings: TraeSettings = merge(config, requestConfig);
     return request(endpoint, {
       ...settings,
       method: 'POST',
@@ -69,7 +68,7 @@ function createTrae(providedConf?: Partial<TraeSettings>) {
     body: unknown = {},
     requestConfig?: RequestInit,
   ) {
-    const settings: TraeSettings = merge({}, config, requestConfig);
+    const settings: TraeSettings = merge(config, requestConfig);
     return request(endpoint, {
       ...settings,
       method: 'PUT',
@@ -82,7 +81,7 @@ function createTrae(providedConf?: Partial<TraeSettings>) {
     body: unknown = {},
     requestConfig?: RequestInit,
   ) {
-    const settings: TraeSettings = merge({}, config, requestConfig);
+    const settings: TraeSettings = merge(config, requestConfig);
     return request(endpoint, {
       ...settings,
       method: 'PATCH',

--- a/src/url.ts
+++ b/src/url.ts
@@ -1,4 +1,4 @@
-import { stringify as stringifyParams } from 'qs';
+import { stringify as stringifyParams } from 'query-string';
 
 interface Params {
   [x: string]: unknown;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,14 @@
+type WithHeaders = { headers: unknown };
+
+// TODO: do not use `any`
+export const merge = (...objs: any[]) => {
+  const headers = objs
+    .filter((obj): obj is WithHeaders =>
+      typeof obj === 'object' && obj ? Boolean(obj.headers) : false,
+    )
+    .map((obj) => obj.headers);
+
+  return headers.length > 0
+    ? Object.assign({}, ...objs, { headers: Object.assign({}, ...headers) })
+    : Object.assign({}, ...objs);
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@ type WithHeaders = { headers: unknown };
 export const merge = (...objs: any[]) => {
   const headers = objs
     .filter((obj): obj is WithHeaders =>
-      typeof obj === 'object' && obj ? Boolean(obj.headers) : false,
+      typeof obj === 'object' && obj ? !!obj.headers : false,
     )
     .map((obj) => obj.headers);
 

--- a/test/delete.spec.ts
+++ b/test/delete.spec.ts
@@ -102,55 +102,6 @@ describe('trae -> delete', () => {
         expect(actual).toStrictEqual(expected);
       });
     });
-
-    describe('delete using nested params', function () {
-      let request;
-      let response;
-
-      beforeAll(function createNock() {
-        request = nock(TEST_URL, {
-          reqheaders: {
-            'content-type': 'application/json',
-          },
-        })
-          .delete('/foo?a%5Bb%5D=c')
-          .reply(200);
-      });
-
-      beforeAll(function executeRequest() {
-        return trae.delete(TEST_URL + '/foo', {
-          params: {
-            a: {
-              b: 'c',
-            },
-          },
-        })
-          .then(function (res) {
-            response = res
-          })
-      });
-
-      it('should make an HTTP delete request', function () {
-        const actual = request.isDone();
-        const expected = true;
-
-        expect(actual).toStrictEqual(expected);
-      });
-
-      it('should have 200 in the response status code', function () {
-        const actual = response.status;
-        const expected = 200;
-
-        expect(actual).toStrictEqual(expected);
-      });
-
-      it('should have "OK" in the response status text', function () {
-        const actual = response.statusText;
-        const expected = 'OK';
-
-        expect(actual).toStrictEqual(expected);
-      });
-    });
   });
 
   describe('Using http server', () => {

--- a/test/get.spec.ts
+++ b/test/get.spec.ts
@@ -109,55 +109,6 @@ describe('trae -> get', () => {
         expect(actual).toStrictEqual(expected);
       });
     });
-
-    describe('get using nested params', function() {
-      let request;
-      let response;
-
-      beforeAll(function createNock() {
-        request = nock(TEST_URL, {
-          reqheaders: {
-            'content-type': 'application/json',
-          },
-        })
-          .get('/foo?a%5Bb%5D=c')
-          .reply(200);
-      });
-
-      beforeAll(function executeRequest() {
-        return trae.get(TEST_URL + '/foo', {
-          params: {
-            a: {
-              b: 'c',
-            },
-          },
-        })
-          .then(function (res) {
-            response = res
-          })
-      });
-
-      it('should make an HTTP get request', function() {
-        const actual = request.isDone();
-        const expected = true;
-
-        expect(actual).toStrictEqual(expected);
-      });
-
-      it('should have 200 in the response status code', function() {
-        const actual = response.status;
-        const expected = 200;
-
-        expect(actual).toStrictEqual(expected);
-      });
-
-      it('should have "OK" in the response status text', function() {
-        const actual = response.statusText;
-        const expected = 'OK';
-
-        expect(actual).toStrictEqual(expected);
-      });
-    });
   });
 
   describe('Using http server', () => {

--- a/test/lib.url.spec.ts
+++ b/test/lib.url.spec.ts
@@ -10,7 +10,6 @@ describe('URL Handler', () => {
       const params = { bar: 'bar', foo: 'foo' };
       const actual = concatParams(url, params);
       const expectted = 'https://www.foo.com/bar?bar=bar&foo=foo';
-      const url = 'https://www.foo.com/bar';
 
       expect(actual).toBe(expectted);
     });

--- a/test/lib.url.spec.ts
+++ b/test/lib.url.spec.ts
@@ -3,29 +3,22 @@
 
 import { format, isAbsolute, combine, concatParams } from '../src/url';
 
-
 describe('URL Handler', () => {
-
   describe('concatParams', () => {
     it('stringify and concats params to the provided URL', () => {
-      const url    = 'https://www.foo.com/bar';
-      const params =  {
-        foo: {
-          bar: {
-            baz: 'foobarbaz'
-          }
-        }
-      };
-      const actual = concatParams(url, params)
-      const expectted = 'https://www.foo.com/bar?foo%5Bbar%5D%5Bbaz%5D=foobarbaz'
+      const url = 'https://www.foo.com/bar';
+      const params = { bar: 'bar', foo: 'foo' };
+      const actual = concatParams(url, params);
+      const expectted = 'https://www.foo.com/bar?bar=bar&foo=foo';
+      const url = 'https://www.foo.com/bar';
 
       expect(actual).toBe(expectted);
     });
 
     it('when params are an empty object it returns the same url', () => {
       const url = 'https://www.foo.com/bar';
-      const params = {}
-      const actual = concatParams(url, {})
+      const params = {};
+      const actual = concatParams(url, {});
 
       expect(actual).toBe(url);
     });
@@ -33,16 +26,16 @@ describe('URL Handler', () => {
 
   describe('combine', () => {
     it('creates and return a new URL by combining the specified URLs', () => {
-      const url1  = 'https://www.foo.com/';
+      const url1 = 'https://www.foo.com/';
       const path1 = '/bar';
 
-      const url2  = 'https://www.foo.com';
+      const url2 = 'https://www.foo.com';
       const path2 = '/bar';
 
-      const url3  = 'https://www.foo.com/';
+      const url3 = 'https://www.foo.com/';
       const path3 = 'bar';
 
-      const url4  = 'https://www.foo.com';
+      const url4 = 'https://www.foo.com';
       const path4 = 'bar';
 
       expect(combine(url1, path1)).toEqual('https://www.foo.com/bar');
@@ -54,8 +47,8 @@ describe('URL Handler', () => {
 
   describe('isAbsolute', () => {
     it('determines whether the specified URL is absolute', () => {
-      const url1  = 'https://www.foo.com/';
-      const url2  = 'https://www.foo.com/bar';
+      const url1 = 'https://www.foo.com/';
+      const url2 = 'https://www.foo.com/bar';
       const path1 = '/bar';
       const path2 = 'bar';
 
@@ -68,41 +61,41 @@ describe('URL Handler', () => {
 
   describe('format', () => {
     it('returns the relative url if base url argument is not defined', () => {
-      const baseUrl     = undefined;
+      const baseUrl = undefined;
       const relativeURL = 'https://www.foo.com/bar';
-      const actual = format(baseUrl, relativeURL)
-      const expected = relativeURL
+      const actual = format(baseUrl, relativeURL);
+      const expected = relativeURL;
 
       expect(actual).toBe(expected);
     });
 
     it('returns the relative url if it is an absolute url', () => {
-      const baseUrl     = 'https://www.foo.com/baz';
+      const baseUrl = 'https://www.foo.com/baz';
       const relativeURL = 'https://www.foo.com/bar';
 
       const actual = format(baseUrl, relativeURL);
-      const expected = relativeURL
+      const expected = relativeURL;
 
       expect(actual).toBe(expected);
     });
 
     it('returns base and realative url combined', () => {
-      const baseUrl     = 'https://www.foo.com/baz/';
+      const baseUrl = 'https://www.foo.com/baz/';
       const relativeURL = '/foo';
       const actual = format(baseUrl, relativeURL);
-      const expected = 'https://www.foo.com/baz/foo'
+      const expected = 'https://www.foo.com/baz/foo';
 
       expect(actual).toBe(expected);
     });
 
     it('returns base, realative url and params combined', () => {
-      const baseUrl     = 'https://www.foo.com/baz/';
+      const baseUrl = 'https://www.foo.com/baz/';
       const relativeURL = '/foo';
-      const params      = {
-        foo: 'bar'
+      const params = {
+        foo: 'bar',
       };
-      const actual = format(baseUrl, relativeURL, params)
-      const expected = 'https://www.foo.com/baz/foo?foo=bar'
+      const actual = format(baseUrl, relativeURL, params);
+      const expected = 'https://www.foo.com/baz/foo?foo=bar';
 
       expect(actual).toBe(expected);
     });

--- a/test/patch.spec.ts
+++ b/test/patch.spec.ts
@@ -105,55 +105,6 @@ describe('trae -> patch', () => {
         expect(actual).toStrictEqual(expected);
       });
     });
-
-    describe('patch using nested params', function () {
-      let request;
-
-      beforeAll(function createNock() {
-        request = nock(TEST_URL, {
-          reqheaders: {
-            'content-type': 'application/json',
-          },
-        })
-          .patch('/foo?a%5Bb%5D=c')
-          .reply(200);
-      });
-
-      beforeAll(function executeRequest() {
-        return trae.patch(
-          TEST_URL + '/foo',
-          {},
-          {
-            params: {
-              a: {
-                b: 'c',
-              },
-            },
-          },
-        );
-      });
-
-      it('should make an HTTP patch request', function () {
-        const actual = request.isDone();
-        const expected = true;
-
-        expect(actual).toStrictEqual(expected);
-      });
-
-      it('should have 200 in the response status code', function () {
-        const actual = response.status;
-        const expected = 200;
-
-        expect(actual).toStrictEqual(expected);
-      });
-
-      it('should have "OK" in the response status text', function () {
-        const actual = response.statusText;
-        const expected = 'OK';
-
-        expect(actual).toStrictEqual(expected);
-      });
-    });
   });
 
   describe('Using http server', () => {

--- a/test/post.spec.ts
+++ b/test/post.spec.ts
@@ -105,55 +105,6 @@ describe('trae -> post', () => {
         expect(actual).toStrictEqual(expected);
       });
     });
-
-    describe('post using nested params', function() {
-      let request;
-
-      beforeAll(function createNock() {
-        request = nock(TEST_URL, {
-          reqheaders: {
-            'content-type': 'application/json',
-          },
-        })
-          .post('/foo?a%5Bb%5D=c')
-          .reply(200);
-      });
-
-      beforeAll(function executeRequest() {
-        return trae.post(
-          TEST_URL + '/foo',
-          {},
-          {
-            params: {
-              a: {
-                b: 'c',
-              },
-            },
-          },
-        );
-      });
-
-      it('should make an HTTP post request', function() {
-        const actual = request.isDone();
-        const expected = true;
-
-        expect(actual).toStrictEqual(expected);
-      });
-
-      it('should have 200 in the response status code', function() {
-        const actual = response.status;
-        const expected = 200;
-
-        expect(actual).toStrictEqual(expected);
-      });
-
-      it('should have "OK" in the response status text', function() {
-        const actual = response.statusText;
-        const expected = 'OK';
-
-        expect(actual).toStrictEqual(expected);
-      });
-    });
   });
 
   describe('Using http server', () => {

--- a/test/put.spec.ts
+++ b/test/put.spec.ts
@@ -105,55 +105,6 @@ describe('trae -> put', () => {
         expect(actual).toStrictEqual(expected);
       });
     });
-
-    describe('put using nested params', function () {
-      let request;
-
-      beforeAll(function createNock() {
-        request = nock(TEST_URL, {
-          reqheaders: {
-            'content-type': 'application/json',
-          },
-        })
-          .put('/foo?a%5Bb%5D=c')
-          .reply(200);
-      });
-
-      beforeAll(function executeRequest() {
-        return trae.put(
-          TEST_URL + '/foo',
-          {},
-          {
-            params: {
-              a: {
-                b: 'c',
-              },
-            },
-          },
-        );
-      });
-
-      it('should make an HTTP put request', function () {
-        const actual = request.isDone();
-        const expected = true;
-
-        expect(actual).toStrictEqual(expected);
-      });
-
-      it('should have 200 in the response status code', function () {
-        const actual = response.status;
-        const expected = 200;
-
-        expect(actual).toStrictEqual(expected);
-      });
-
-      it('should have "OK" in the response status text', function () {
-        const actual = response.statusText;
-        const expected = 'OK';
-
-        expect(actual).toStrictEqual(expected);
-      });
-    });
   });
 
   describe('Using http server', () => {


### PR DESCRIPTION
Replaced dependencies
- `qs` with [query-string](https://github.com/sindresorhus/query-string): no more nested object, so those tests were removed.
- `lodash/merge` with a small util that used `Object.assign` and specially handles `headers` since is the only nested thing in our config. This one needs to be improved a bit, but the solution works (at least tests pass 🤐)

Before (master)

<img width="451" alt="Screenshot 2020-03-17 at 23 59 14" src="https://user-images.githubusercontent.com/8309423/76909393-674cbc80-68ab-11ea-8b50-0f8c9ef6dab1.png">

After

<img width="458" alt="Screenshot 2020-03-17 at 23 58 42" src="https://user-images.githubusercontent.com/8309423/76909406-6f0c6100-68ab-11ea-9c2e-297c89122b8f.png">
